### PR TITLE
List command with alignment printer

### DIFF
--- a/src/dotnet-uninstall/Shared/Commands/ListCommandExec.cs
+++ b/src/dotnet-uninstall/Shared/Commands/ListCommandExec.cs
@@ -39,7 +39,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
 
             if ((typeSelection & BundleType.Sdk) > 0)
             {
-                var sdks = Bundle<SdkVersion>.FilterWithSameBundleType(bundles).OrderByDescending(sdk => sdk.Version);
+                var sdks = Bundle<SdkVersion>.FilterWithSameBundleType(bundles).OrderByDescending(sdk => sdk);
 
                 Console.WriteLine(".NET Core SDKs:");
                 alignPrinter.Print(sdks.Select(sdk => GetTupleForAlignPrinter(sdk)));
@@ -54,7 +54,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
                     Console.WriteLine();
                 }
 
-                var runtimes = Bundle<RuntimeVersion>.FilterWithSameBundleType(bundles).OrderByDescending(runtime => runtime.Version);
+                var runtimes = Bundle<RuntimeVersion>.FilterWithSameBundleType(bundles).OrderByDescending(runtime => runtime);
 
                 Console.WriteLine(".NET Core Runtimes:");
                 alignPrinter.Print(runtimes.Select(runtime => GetTupleForAlignPrinter(runtime)));

--- a/src/dotnet-uninstall/Shared/Commands/ListCommandExec.cs
+++ b/src/dotnet-uninstall/Shared/Commands/ListCommandExec.cs
@@ -35,14 +35,15 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             var typeSelection = listCommandParseResult.CommandResult.GetTypeSelection();
             var printed = false;
 
+            var alignPrinter = new AlignPrinter<(string, string)>(new[] { AlignType.Left, AlignType.Left }, "    ", "  ");
+
             if ((typeSelection & BundleType.Sdk) > 0)
             {
                 var sdks = Bundle<SdkVersion>.FilterWithSameBundleType(bundles).OrderByDescending(sdk => sdk.Version);
+
                 Console.WriteLine(".NET Core SDKs:");
-                foreach (var sdk in sdks)
-                {
-                    Console.WriteLine($"\t{sdk.ToString()}");
-                }
+                alignPrinter.Print(sdks.Select(sdk => GetTupleForAlignPrinter(sdk)));
+
                 printed = true;
             }
 
@@ -54,12 +55,15 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
                 }
 
                 var runtimes = Bundle<RuntimeVersion>.FilterWithSameBundleType(bundles).OrderByDescending(runtime => runtime.Version);
+
                 Console.WriteLine(".NET Core Runtimes:");
-                foreach (var runtime in runtimes)
-                {
-                    Console.WriteLine($"\t{runtime.ToString()}");
-                }
+                alignPrinter.Print(runtimes.Select(runtime => GetTupleForAlignPrinter(runtime)));
             }
+        }
+
+        private static (string, string) GetTupleForAlignPrinter(Bundle bundle)
+        {
+            return (bundle.Version.ToString(), $"({bundle.Arch.ToString().ToLower()})");
         }
     }
 }

--- a/src/dotnet-uninstall/Shared/Utils/AlignPrinter.cs
+++ b/src/dotnet-uninstall/Shared/Utils/AlignPrinter.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Microsoft.DotNet.Tools.Uninstall.Shared.Utils
+{
+    internal class AlignPrinter<TTuple> where TTuple : ITuple
+    {
+        private readonly IList<AlignType> _alignTypes;
+        private readonly string _separator;
+        private readonly string _prefix;
+        private readonly string _suffix;
+
+        public AlignPrinter(IList<AlignType> alignTypes, string separator = " ", string prefix = "", string suffix = "")
+        {
+            _alignTypes = alignTypes;
+            _separator = separator;
+            _prefix = prefix;
+            _suffix = suffix;
+        }
+
+        public string GetFormatString(IEnumerable<TTuple> tuples)
+        {
+            if (tuples == null)
+            {
+                throw new ArgumentNullException();
+            }
+
+            if (tuples.Any(tuple => tuple.Length != _alignTypes.Count))
+            {
+                throw new ArgumentException();
+            }
+
+            var columnFormatStrings = Enumerable
+                .Range(0, _alignTypes.Count)
+                .Select(column =>
+                (
+                    column,
+                    alignType: _alignTypes[column],
+                    maxLength: tuples.Select(tuple => tuple[column].ToString().Length as int?).Max() ?? 0
+                ))
+                .Select(tuple => $"{{{tuple.column}, {GetAlignString(tuple.alignType)}{tuple.maxLength}}}");
+
+            return $"{_prefix}{string.Join(_separator, columnFormatStrings)}{_suffix}";
+        }
+
+        public IEnumerable<string> GetAlignedRows(IEnumerable<TTuple> tuples)
+        {
+            var format = GetFormatString(tuples);
+
+            if (tuples.Any(tuple => tuple.Length != _alignTypes.Count))
+            {
+                throw new ArgumentException();
+            }
+
+            return tuples.Select(tuple =>
+            {
+                var args = Enumerable
+                    .Range(0, _alignTypes.Count)
+                    .Select(column => tuple[column]);
+
+                return string.Format(format, args.ToArray());
+            });
+        }
+
+        public void Print(IEnumerable<TTuple> tuples)
+        {
+            var aligned = GetAlignedRows(tuples);
+
+            foreach (var row in aligned)
+            {
+                Console.WriteLine(row);
+            }
+        }
+
+        private string GetAlignString(AlignType type)
+        {
+            switch (type)
+            {
+                case AlignType.Left: return "-";
+                case AlignType.Right: return "";
+                default: throw new InvalidEnumArgumentException();
+            }
+        }
+    }
+
+    internal enum AlignType
+    {
+        Left,
+        Right
+    }
+}


### PR DESCRIPTION
@KathleenDollard mentioned during an offline conversation that the `list` command could be improved by having multiple columns for versions and for architectures. Hence, I added an alignment printer to achieve this.

Before:
```
.NET Core SDKs:
        3.0.100-preview6-012264 (x64)
        2.2.300 (x64)
        2.1.603 (x64)
        2.1.507 (x64)
        2.1.4 (x64)
        1.1.10 (x64)

.NET Core Runtimes:
        2.2.5 (x64)
        2.2.4 (x64)
        2.1.0-rc1 (x64)
        2.0.5 (x64)
```

Now:
```
.NET Core SDKs:
  3.0.100-preview6-012264    (x64)
  2.2.300                    (x64)
  2.1.603                    (x64)
  2.1.507                    (x64)
  2.1.4                      (x64)
  1.1.10                     (x64)

.NET Core Runtimes:
  2.2.5        (x64)
  2.2.4        (x64)
  2.1.0-rc1    (x64)
  2.0.5        (x64)
```

_Note: This is currently a draft because unit tests are not complete. However review is welcome._