### PR TITLE
TableView for `list` command output

### DIFF
--- a/src/dotnet-uninstall/Messages.cs
+++ b/src/dotnet-uninstall/Messages.cs
@@ -37,6 +37,9 @@
         public static readonly string SdkOptionDescription = "Uninstall the .NET Core SDKs only";
         public static readonly string RuntimeOptionDescription = "Uninstall the .NET Core Runtimes only";
 
+        public static readonly string ListCommandSdkHeader = ".NET Core SDKs:";
+        public static readonly string ListCommandRuntimeHeader = ".NET Core Runtimes:";
+
         public static readonly string LinuxNotSupportedExceptionMessage = "The Linux operating systems are not supported";
         public static readonly string BundleTypeNotSpecifiedExceptionMessage = "Please specified the bundle type to uninstall";
         public static readonly string RequiredArgMissingForUninstallCommandExceptionMessage = "Required argument missing for the uninstall command";

--- a/src/dotnet-uninstall/dotnet-uninstall.csproj
+++ b/src/dotnet-uninstall/dotnet-uninstall.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
     <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19174.3" />
+    <PackageReference Include="System.CommandLine.Rendering" Version="0.2.0-alpha.19174.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
@KathleenDollard mentioned during an offline conversation that the `list` command could be improved by having multiple columns for versions and for architectures. Hence, I added an alignment printer to achieve this.

Before:
```
.NET Core SDKs:
        3.0.100-preview6-012264 (x64)
        2.2.300 (x64)
        2.1.603 (x64)
        2.1.507 (x64)
        2.1.4 (x64)
        1.1.10 (x64)

.NET Core Runtimes:
        2.2.5 (x64)
        2.2.4 (x64)
        2.1.0-rc1 (x64)
        2.0.5 (x64)
```

Now:
```
.NET Core SDKs:
  3.0.100-preview6-012264  (x64)
  2.2.300                  (x64)
  2.1.603                  (x64)
  2.1.507                  (x64)
  2.1.4                    (x64)
  1.1.10                   (x64)

.NET Core Runtimes:
  2.2.5              (x64)
  2.2.4              (x64)
  2.1.0-rc1          (x64)
  2.0.5              (x64)
```

_Note: This is currently a draft because unit tests are not complete. However review is welcome._