### PR TITLE
Support `<major>.<minor>` for the `--all-below` option

### DIFF
--- a/src/dotnet-uninstall/Shared/BundleInfo/BundleVersion.cs
+++ b/src/dotnet-uninstall/Shared/BundleInfo/BundleVersion.cs
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo
 
             major = int.Parse(majorString);
             minor = int.Parse(minorString);
-            patch = int.Parse(patchString);
+            patch = patchString.Equals(string.Empty) ? default : int.Parse(patchString);
             build = buildString.Equals(string.Empty) ? default : int.Parse(buildString);
             preview = match.Groups[Regexes.PreviewGroupName].Success;
         }

--- a/src/dotnet-uninstall/Shared/Utils/Regexes.cs
+++ b/src/dotnet-uninstall/Shared/Utils/Regexes.cs
@@ -63,8 +63,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Utils
         public static readonly Regex BundleCachePathRegex = new Regex(
             $@"(\\dotnet\-((?<{TypeGroupName}>sdk)\-{_sdkVersionCachePathRegex}|(?<{TypeGroupName}>runtime)\-{_runtimeVersionCachePathRegex})\-win\-{_archRegex.ToString()}\.exe$)|(\\dotnet\-dev\-win\-{_archRegex.ToString()}\.{_sdkVersionCachePathRegex.ToString()}\.exe$)|(\\dotnet\-win\-{_archRegex.ToString()}\.{_runtimeVersionCachePathRegex.ToString()}\.exe$)");
         public static readonly Regex SdkVersionInputRegex = new Regex(
-            $@"^{_sdkVersionCachePathRegex}$");
+            $@"^{_sdkVersionCachePathRegex}$|^{_majorMinorRegex.ToString()}$");
         public static readonly Regex RuntimeVersionInputRegex = new Regex(
-            $@"^{_runtimeVersionCachePathRegex}$");
+            $@"^{_runtimeVersionCachePathRegex}$|^{_majorMinorRegex.ToString()}$");
     }
 }

--- a/test/dotnet-uninstall.Tests/Shared/BundleInfo/RuntimeVersionTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/BundleInfo/RuntimeVersionTests.cs
@@ -188,6 +188,14 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.BundleInfo
         [InlineData("2.2.5", 2, 2, 5, 0, false)]
         [InlineData("3.0.0-preview-27122-01", 3, 0, 0, 27122, true)]
         [InlineData("3.0.0-preview5-27626-15", 3, 0, 0, 27626, true)]
+        [InlineData("1.0", 1, 0, 0, 0, false)]
+        [InlineData("1.1", 1, 1, 0, 0, false)]
+        [InlineData("2.0", 2, 0, 0, 0, false)]
+        [InlineData("2.1", 2, 1, 0, 0, false)]
+        [InlineData("2.2", 2, 2, 0, 0, false)]
+        [InlineData("3.0", 3, 0, 0, 0, false)]
+        [InlineData("12.345", 12, 345, 0, 0, false)]
+        [InlineData("0012.00345", 12, 345, 0, 0, false)]
         internal void TestFromInputAccept(string input, int major, int minor, int patch, int build, bool preview)
         {
             var version = BundleVersion.FromInput<RuntimeVersion>(input) as RuntimeVersion;
@@ -201,7 +209,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.BundleInfo
         }
 
         [Theory]
-        [InlineData("1.0")]
         [InlineData("1.0.")]
         [InlineData("2.0.0-preview")]
         [InlineData("2.0.0-preview1")]

--- a/test/dotnet-uninstall.Tests/Shared/BundleInfo/SdkVersionTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/BundleInfo/SdkVersionTests.cs
@@ -199,6 +199,14 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.BundleInfo
         [InlineData("2.2.300", 2, 2, 3, 0, 0, false)]
         [InlineData("3.0.100-preview-009812", 3, 0, 1, 0, 9812, true)]
         [InlineData("3.0.100-preview6-012264", 3, 0, 1, 0, 12264, true)]
+        [InlineData("1.0", 1, 0, 0, 0, 0, false)]
+        [InlineData("1.1", 1, 1, 0, 0, 0, false)]
+        [InlineData("2.0", 2, 0, 0, 0, 0, false)]
+        [InlineData("2.1", 2, 1, 0, 0, 0, false)]
+        [InlineData("2.2", 2, 2, 0, 0, 0, false)]
+        [InlineData("3.0", 3, 0, 0, 0, 0, false)]
+        [InlineData("12.345", 12, 345, 0, 0, 0, false)]
+        [InlineData("0012.00345", 12, 345, 0, 0, 0, false)]
         internal void TestFromInputAccept(string input, int major, int minor, int sdkMinor, int patch, int build, bool preview)
         {
             var version = BundleVersion.FromInput<SdkVersion>(input) as SdkVersion;
@@ -213,7 +221,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.BundleInfo
         }
 
         [Theory]
-        [InlineData("1.0")]
         [InlineData("1.0.")]
         [InlineData("2.2.5.002111")]
         [InlineData("2.2.500.002111")]

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllBelowOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllBelowOptionFiltererTests.cs
@@ -223,6 +223,74 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 BundleType.Runtime,
                 BundleArch.X64 | BundleArch.Arm32
             };
+
+            yield return new object[]
+            {
+                DefaultTestBundles,
+                "2.3",
+                new List<Bundle>
+                {
+                    Sdk_2_2_300_X64,
+                    Sdk_2_2_222_X86,
+                    Sdk_2_2_202_X86,
+                    Sdk_2_2_202_Arm32,
+                    Sdk_2_1_700_X64,
+                    Sdk_2_1_300_Rc1_X86,
+                    Sdk_2_1_300_Rc1_Arm32
+                },
+                BundleType.Sdk,
+                DefaultTestArchSelection
+            };
+
+            yield return new object[]
+            {
+                DefaultTestBundles,
+                "3.0",
+                new List<Bundle>
+                {
+                    Runtime_2_2_5_Arm32,
+                    Runtime_2_2_2_X64,
+                    Runtime_2_1_0_Rc1_X64
+                },
+                BundleType.Runtime,
+                BundleArch.Arm32 | BundleArch.X64
+            };
+
+            yield return new object[]
+            {
+                DefaultTestBundles,
+                "2.0",
+                new List<Bundle>(),
+                BundleType.Sdk,
+                DefaultTestArchSelection
+            };
+
+            yield return new object[]
+            {
+                DefaultTestBundles,
+                "2.1",
+                new List<Bundle>(),
+                BundleType.Runtime,
+                DefaultTestArchSelection
+            };
+
+            yield return new object[]
+            {
+                DefaultTestBundles,
+                "3.1",
+                DefaultTestSdks,
+                BundleType.Sdk,
+                DefaultTestArchSelection
+            };
+
+            yield return new object[]
+            {
+                DefaultTestBundles,
+                "3.1",
+                DefaultTestRuntimes,
+                BundleType.Runtime,
+                DefaultTestArchSelection
+            };
         }
 
         [Theory]

--- a/test/dotnet-uninstall.Tests/Shared/Utils/RegexesTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Utils/RegexesTests.cs
@@ -211,13 +211,20 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Utils
         [InlineData("2.2.300")]
         [InlineData("3.0.100-preview-009812")]
         [InlineData("3.0.100-preview6-012264")]
+        [InlineData("1.0")]
+        [InlineData("1.1")]
+        [InlineData("2.0")]
+        [InlineData("2.1")]
+        [InlineData("2.2")]
+        [InlineData("3.0")]
+        [InlineData("12.345")]
+        [InlineData("0012.00345")]
         internal void TestSdkVersionInputRegexAccept(string input)
         {
             TestRegexAccept(Regexes.SdkVersionInputRegex, input);
         }
 
         [Theory]
-        [InlineData("1.0")]
         [InlineData("1.0.")]
         [InlineData("2.2.5.002111")]
         [InlineData("2.2.500.002111")]
@@ -250,13 +257,20 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Utils
         [InlineData("2.2.5")]
         [InlineData("3.0.0-preview-27122-01")]
         [InlineData("3.0.0-preview5-27626-15")]
+        [InlineData("1.0")]
+        [InlineData("1.1")]
+        [InlineData("2.0")]
+        [InlineData("2.1")]
+        [InlineData("2.2")]
+        [InlineData("3.0")]
+        [InlineData("12.345")]
+        [InlineData("0012.00345")]
         internal void TestRuntimeVersionInputRegexAccept(string input)
         {
             TestRegexAccept(Regexes.RuntimeVersionInputRegex, input);
         }
 
         [Theory]
-        [InlineData("1.0")]
         [InlineData("1.0.")]
         [InlineData("2.0.0-preview")]
         [InlineData("2.0.0-preview1")]


### PR DESCRIPTION
@KathleenDollard mentioned during an offline conversation that it would be convenient for users to be able to specify `<major>.<minor>` only for the `--all-below` option. Hence I add the functionality.

The main approach to achieve this is to parse `<major>.<minor>` as `<major>.<minor>.0.0`, where the patch number and the build number are both `0`.

Covered by unit tests.