### PR TITLE
Disallowed `--sdk` and `--runtime` to occur simultaneously

### DIFF
--- a/src/dotnet-uninstall/Shared/Filterers/AllBelowOptionFilterer.cs
+++ b/src/dotnet-uninstall/Shared/Filterers/AllBelowOptionFilterer.cs
@@ -6,8 +6,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 {
     internal class AllBelowOptionFilterer : ArgFilterer<string>
     {
-        public override bool AcceptMultipleBundleTypes { get; } = false;
-
         public override IEnumerable<Bundle<TBundleVersion>> Filter<TBundleVersion>(string argValue, IEnumerable<Bundle<TBundleVersion>> bundles)
         {
             var specifiedVersion = BundleVersion.FromInput<TBundleVersion>(argValue) as TBundleVersion;

--- a/src/dotnet-uninstall/Shared/Filterers/AllButLatestOptionFilterer.cs
+++ b/src/dotnet-uninstall/Shared/Filterers/AllButLatestOptionFilterer.cs
@@ -6,8 +6,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 {
     internal class AllButLatestOptionFilterer : NoArgFilterer
     {
-        public override bool AcceptMultipleBundleTypes { get; } = true;
-
         public override IEnumerable<Bundle<TBundleVersion>> Filter<TBundleVersion>(IEnumerable<Bundle<TBundleVersion>> bundles)
         {
             var latestSdk = bundles

--- a/src/dotnet-uninstall/Shared/Filterers/AllButOptionFilterer.cs
+++ b/src/dotnet-uninstall/Shared/Filterers/AllButOptionFilterer.cs
@@ -7,8 +7,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 {
     internal class AllButOptionFilterer : ArgFilterer<IEnumerable<string>>
     {
-        public override bool AcceptMultipleBundleTypes { get; } = false;
-
         public override IEnumerable<Bundle<TBundleVersion>> Filter<TBundleVersion>(IEnumerable<string> argValue, IEnumerable<Bundle<TBundleVersion>> bundles)
         {
             var specifiedVersions = bundles

--- a/src/dotnet-uninstall/Shared/Filterers/AllLowerPatchesOptionFilterer.cs
+++ b/src/dotnet-uninstall/Shared/Filterers/AllLowerPatchesOptionFilterer.cs
@@ -8,8 +8,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 {
     internal class AllLowerPatchesOptionFilterer : NoArgFilterer
     {
-        public override bool AcceptMultipleBundleTypes { get; } = true;
-
         public override IEnumerable<Bundle<TBundleVersion>> Filter<TBundleVersion>(IEnumerable<Bundle<TBundleVersion>> bundles)
         {
             var highestPatches = new Dictionary<Tuple<int, int, int>, int>();

--- a/src/dotnet-uninstall/Shared/Filterers/AllOptionFilterer.cs
+++ b/src/dotnet-uninstall/Shared/Filterers/AllOptionFilterer.cs
@@ -5,8 +5,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 {
     internal class AllOptionFilterer : NoArgFilterer
     {
-        public override bool AcceptMultipleBundleTypes { get; } = true;
-
         public override IEnumerable<Bundle<TBundleVersion>> Filter<TBundleVersion>(IEnumerable<Bundle<TBundleVersion>> bundles)
         {
             return bundles;

--- a/src/dotnet-uninstall/Shared/Filterers/AllPreviewsButLatestOptionFilterer.cs
+++ b/src/dotnet-uninstall/Shared/Filterers/AllPreviewsButLatestOptionFilterer.cs
@@ -6,8 +6,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 {
     internal class AllPreviewsButLatestOptionFilterer : NoArgFilterer
     {
-        public override bool AcceptMultipleBundleTypes { get; } = true;
-
         public override IEnumerable<Bundle<TBundleVersion>> Filter<TBundleVersion>(IEnumerable<Bundle<TBundleVersion>> bundles)
         {
             var latestSdk = bundles

--- a/src/dotnet-uninstall/Shared/Filterers/AllPreviewsOptionFilterer.cs
+++ b/src/dotnet-uninstall/Shared/Filterers/AllPreviewsOptionFilterer.cs
@@ -6,8 +6,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 {
     internal class AllPreviewsOptionFilterer : NoArgFilterer
     {
-        public override bool AcceptMultipleBundleTypes { get; } = true;
-
         public override IEnumerable<Bundle<TBundleVersion>> Filter<TBundleVersion>(IEnumerable<Bundle<TBundleVersion>> bundles)
         {
             return bundles

--- a/src/dotnet-uninstall/Shared/Filterers/Filterer.cs
+++ b/src/dotnet-uninstall/Shared/Filterers/Filterer.cs
@@ -9,8 +9,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 {
     internal abstract class Filterer
     {
-        public abstract bool AcceptMultipleBundleTypes { get; }
-
         public abstract IEnumerable<Bundle> Filter(ParseResult parseResult, Option option, IEnumerable<Bundle> bundles, BundleType typeSelection, BundleArch archSelection);
 
         protected void ValidateTypeSelection(BundleType typeSelection)
@@ -20,7 +18,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
                 throw new ArgumentOutOfRangeException();
             }
 
-            if (!AcceptMultipleBundleTypes && typeSelection != BundleType.Sdk && typeSelection != BundleType.Runtime)
+            if (typeSelection != BundleType.Sdk && typeSelection != BundleType.Runtime)
             {
                 throw new BundleTypeMissingException();
             }
@@ -29,8 +27,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 
     internal abstract class ArgFilterer<TArg> : Filterer
     {
-        public abstract override bool AcceptMultipleBundleTypes { get; }
-
         public override IEnumerable<Bundle> Filter(ParseResult parseResult, Option option, IEnumerable<Bundle> bundles, BundleType typeSelection, BundleArch archSelection)
         {
             var argValue = parseResult.ValueForOption<TArg>(option.Name);
@@ -63,8 +59,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 
     internal abstract class NoArgFilterer : Filterer
     {
-        public abstract override bool AcceptMultipleBundleTypes { get; }
-
         public override IEnumerable<Bundle> Filter(ParseResult parseResult, Option option, IEnumerable<Bundle> bundles, BundleType typeSelection, BundleArch archSelection)
         {
             return Filter(bundles, typeSelection, archSelection);

--- a/src/dotnet-uninstall/Shared/Filterers/MajorMinorOptionFilterer.cs
+++ b/src/dotnet-uninstall/Shared/Filterers/MajorMinorOptionFilterer.cs
@@ -8,8 +8,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 {
     internal class MajorMinorOptionFilterer : ArgFilterer<string>
     {
-        public override bool AcceptMultipleBundleTypes { get; } = true;
-
         public override IEnumerable<Bundle<TBundleVersion>> Filter<TBundleVersion>(string argValue, IEnumerable<Bundle<TBundleVersion>> bundles)
         {
             var match = Regexes.BundleMajorMinorRegex.Match(argValue);

--- a/src/dotnet-uninstall/Shared/Filterers/NoOptionFilterer.cs
+++ b/src/dotnet-uninstall/Shared/Filterers/NoOptionFilterer.cs
@@ -8,8 +8,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
 {
     internal class NoOptionFilterer : ArgFilterer<IEnumerable<string>>
     {
-        public override bool AcceptMultipleBundleTypes { get; } = false;
-
         public override IEnumerable<Bundle<TBundleVersion>> Filter<TBundleVersion>(IEnumerable<string> argValue, IEnumerable<Bundle<TBundleVersion>> bundles)
         {
             var anyMissing = argValue

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllBelowOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllBelowOptionFiltererTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     public class AllBelowOptionFiltererTests : FiltererTests
     {
         internal override Option Option => CommandLineConfigs.UninstallAllBelowOption;
-        internal override string DefaultArgValue => "2.2.5";
+        internal override string DefaultTestArgValue => "2.2.5";
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllBelowOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllBelowOptionFiltererTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal override Option Option => CommandLineConfigs.UninstallAllBelowOption;
         internal override string DefaultArgValue => "2.2.5";
-        internal override bool TestBundleTypeNotSpecifiedException => true;
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllButLatestOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllButLatestOptionFiltererTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     public class AllButLatestOptionFiltererTests : FiltererTests
     {
         internal override Option Option => CommandLineConfigs.UninstallAllButLatestOption;
-        internal override string DefaultArgValue => "";
+        internal override string DefaultTestArgValue => "";
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         [MemberData(nameof(GetDataForTestFiltererGood))]
         internal void TestAllButLatestOptionFiltererGood(IEnumerable<Bundle> testBundles, IEnumerable<Bundle> expected, BundleType typeSelection, BundleArch archSelection)
         {
-            TestFiltererGood(testBundles, DefaultArgValue, expected, typeSelection, archSelection);
+            TestFiltererGood(testBundles, DefaultTestArgValue, expected, typeSelection, archSelection);
         }
     }
 }

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllButLatestOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllButLatestOptionFiltererTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal override Option Option => CommandLineConfigs.UninstallAllButLatestOption;
         internal override string DefaultArgValue => "";
-        internal override bool TestBundleTypeNotSpecifiedException => false;
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {
@@ -52,29 +51,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 DefaultTestBundles,
                 new List<Bundle>
                 {
-                    Sdk_2_2_300_X64,
-                    Sdk_2_2_222_X86,
-                    Sdk_2_2_202_Arm32,
-                    Sdk_2_2_202_X86,
-                    Sdk_2_1_700_X64,
-                    Sdk_2_1_300_Rc1_Arm32,
-                    Sdk_2_1_300_Rc1_X86,
-                    Runtime_3_0_0_P_Arm32,
-                    Runtime_2_2_5_Arm32,
-                    Runtime_2_2_5_X86,
-                    Runtime_2_2_4_X86,
-                    Runtime_2_2_2_X64,
-                    Runtime_2_1_0_Rc1_X64
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                DefaultTestArchSelection
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                new List<Bundle>
-                {
                     Sdk_2_2_202_X86,
                     Sdk_2_1_300_Rc1_X86
                 },
@@ -94,24 +70,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 },
                 BundleType.Runtime,
                 BundleArch.X86 | BundleArch.Arm32
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                new List<Bundle>
-                {
-                    Sdk_2_2_202_Arm32,
-                    Sdk_2_2_202_X86,
-                    Sdk_2_1_300_Rc1_Arm32,
-                    Sdk_2_1_300_Rc1_X86,
-                    Runtime_3_0_0_P_Arm32,
-                    Runtime_2_2_5_Arm32,
-                    Runtime_2_2_5_X86,
-                    Runtime_2_2_4_X86
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                BundleArch.Arm32 | BundleArch.X86
             };
         }
 

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllButOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllButOptionFiltererTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     public class AllButOptionFiltererTests : FiltererTests
     {
         internal override Option Option => CommandLineConfigs.UninstallAllButOption;
-        internal override string DefaultArgValue => "2.2.5";
+        internal override string DefaultTestArgValue => "2.2.5";
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllButOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllButOptionFiltererTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal override Option Option => CommandLineConfigs.UninstallAllButOption;
         internal override string DefaultArgValue => "2.2.5";
-        internal override bool TestBundleTypeNotSpecifiedException => true;
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllLowerPatchesOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllLowerPatchesOptionFiltererTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     public class AllLowerPatchesOptionFiltererTests : FiltererTests
     {
         internal override Option Option => CommandLineConfigs.UninstallAllLowerPatchesOption;
-        internal override string DefaultArgValue => "";
+        internal override string DefaultTestArgValue => "";
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         [MemberData(nameof(GetDataForTestFiltererGood))]
         internal void TestAllLowerPatchesOptionFiltererGood(IEnumerable<Bundle> testBundles, IEnumerable<Bundle> expected, BundleType typeSelection, BundleArch archSelection)
         {
-            TestFiltererGood(testBundles, DefaultArgValue, expected, typeSelection, archSelection);
+            TestFiltererGood(testBundles, DefaultTestArgValue, expected, typeSelection, archSelection);
         }
     }
 }

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllLowerPatchesOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllLowerPatchesOptionFiltererTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal override Option Option => CommandLineConfigs.UninstallAllLowerPatchesOption;
         internal override string DefaultArgValue => "";
-        internal override bool TestBundleTypeNotSpecifiedException => false;
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {
@@ -44,20 +43,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 new List<Bundle>
                 {
                     Sdk_2_2_202_Arm32,
-                    Sdk_2_2_202_X86,
-                    Runtime_2_2_4_X86,
-                    Runtime_2_2_2_X64
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                DefaultTestArchSelection
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                new List<Bundle>
-                {
-                    Sdk_2_2_202_Arm32,
                     Sdk_2_2_202_X86
                 },
                 BundleType.Sdk,
@@ -70,19 +55,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 new List<Bundle>(),
                 BundleType.Runtime,
                 BundleArch.X64
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                new List<Bundle>
-                {
-                    Sdk_2_2_202_Arm32,
-                    Sdk_2_2_202_X86,
-                    Runtime_2_2_4_X86
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                BundleArch.Arm32 | BundleArch.X86
             };
         }
 

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllOptionFiltererTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     public class AllOptionFiltererTests : FiltererTests
     {
         internal override Option Option => CommandLineConfigs.UninstallAllOption;
-        internal override string DefaultArgValue => "";
+        internal override string DefaultTestArgValue => "";
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {
@@ -62,7 +62,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         [MemberData(nameof(GetDataForTestFiltererGood))]
         internal void TestAllOptionFiltererGood(IEnumerable<Bundle> testBundles, IEnumerable<Bundle> expected, BundleType typeSelection, BundleArch archSelection)
         {
-            TestFiltererGood(testBundles, DefaultArgValue, expected, typeSelection, archSelection);
+            TestFiltererGood(testBundles, DefaultTestArgValue, expected, typeSelection, archSelection);
         }
     }
 }

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllOptionFiltererTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal override Option Option => CommandLineConfigs.UninstallAllOption;
         internal override string DefaultArgValue => "";
-        internal override bool TestBundleTypeNotSpecifiedException => false;
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {
@@ -27,14 +26,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 DefaultTestBundles,
                 DefaultTestRuntimes,
                 BundleType.Runtime,
-                DefaultTestArchSelection
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                DefaultTestBundles,
-                BundleType.Sdk | BundleType.Runtime,
                 DefaultTestArchSelection
             };
 
@@ -64,28 +55,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 },
                 BundleType.Runtime,
                 BundleArch.Arm32 | BundleArch.X86
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                new List<Bundle>
-                {
-                    Sdk_2_2_222_X86,
-                    Sdk_2_2_202_X86,
-                    Sdk_2_1_700_X64,
-                    Sdk_3_0_100_P5_X64,
-                    Sdk_2_2_300_X64,
-                    Sdk_2_1_300_Rc1_X86,
-                    Runtime_2_2_2_X64,
-                    Runtime_3_0_0_P5_X64,
-                    Runtime_2_2_4_X86,
-                    Runtime_2_2_5_X86,
-                    Runtime_3_0_0_P5_X86,
-                    Runtime_2_1_0_Rc1_X64
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                BundleArch.X86 | BundleArch.X64
             };
         }
 

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllPreviewsButLatestOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllPreviewsButLatestOptionFiltererTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal override Option Option => CommandLineConfigs.UninstallAllPreviewsButLatestOption;
         internal override string DefaultArgValue => "";
-        internal override bool TestBundleTypeNotSpecifiedException => false;
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {
@@ -35,20 +34,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                     Runtime_2_1_0_Rc1_X64
                 },
                 BundleType.Runtime,
-                DefaultTestArchSelection
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                new List<Bundle>
-                {
-                    Sdk_2_1_300_Rc1_Arm32,
-                    Sdk_2_1_300_Rc1_X86,
-                    Runtime_3_0_0_P_Arm32,
-                    Runtime_2_1_0_Rc1_X64
-                },
-                BundleType.Sdk | BundleType.Runtime,
                 DefaultTestArchSelection
             };
 
@@ -88,19 +73,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 },
                 BundleType.Runtime,
                 BundleArch.Arm32 | BundleArch.X86
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                new List<Bundle>
-                {
-                    Sdk_2_1_300_Rc1_Arm32,
-                    Runtime_3_0_0_P_Arm32,
-                    Runtime_2_1_0_Rc1_X64
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                BundleArch.X64 | BundleArch.Arm32
             };
         }
 

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllPreviewsButLatestOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllPreviewsButLatestOptionFiltererTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     public class AllPreviewsButLatestOptionFiltererTests : FiltererTests
     {
         internal override Option Option => CommandLineConfigs.UninstallAllPreviewsButLatestOption;
-        internal override string DefaultArgValue => "";
+        internal override string DefaultTestArgValue => "";
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {
@@ -80,7 +80,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         [MemberData(nameof(GetDataForTestFiltererGood))]
         internal void TestAllPreviewsButLatestOptionFiltererGood(IEnumerable<Bundle> testBundles, IEnumerable<Bundle> expected, BundleType typeSelection, BundleArch archSelection)
         {
-            TestFiltererGood(testBundles, DefaultArgValue, expected, typeSelection, archSelection);
+            TestFiltererGood(testBundles, DefaultTestArgValue, expected, typeSelection, archSelection);
         }
     }
 }

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllPreviewsOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllPreviewsOptionFiltererTests.cs
@@ -9,7 +9,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     public class AllPreviewsOptionFiltererTests : FiltererTests
     {
         internal override Option Option => CommandLineConfigs.UninstallAllPreviewsOption;
-        internal override string DefaultArgValue => "";
+        internal override string DefaultTestArgValue => "";
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {
@@ -68,7 +68,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         [MemberData(nameof(GetDataForTestFiltererGood))]
         internal void TestAllPreviewsOptionFiltererGood(IEnumerable<Bundle> testBundles, IEnumerable<Bundle> expected, BundleType typeSelection, BundleArch archSelection)
         {
-            TestFiltererGood(testBundles, DefaultArgValue, expected, typeSelection, archSelection);
+            TestFiltererGood(testBundles, DefaultTestArgValue, expected, typeSelection, archSelection);
         }
     }
 }

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/AllPreviewsOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/AllPreviewsOptionFiltererTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal override Option Option => CommandLineConfigs.UninstallAllPreviewsOption;
         internal override string DefaultArgValue => "";
-        internal override bool TestBundleTypeNotSpecifiedException => false;
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {
@@ -46,23 +45,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 DefaultTestBundles,
                 new List<Bundle>
                 {
-                    Sdk_3_0_100_P5_X64,
-                    Sdk_2_1_300_Rc1_Arm32,
-                    Sdk_2_1_300_Rc1_X86,
-                    Runtime_3_0_0_P5_X64,
-                    Runtime_3_0_0_P5_X86,
-                    Runtime_3_0_0_P_Arm32,
-                    Runtime_2_1_0_Rc1_X64
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                DefaultTestArchSelection
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                new List<Bundle>
-                {
                     Sdk_2_1_300_Rc1_Arm32
                 },
                 BundleType.Sdk,
@@ -79,21 +61,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 },
                 BundleType.Runtime,
                 BundleArch.Arm32 | BundleArch.X86
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                new List<Bundle>
-                {
-                    Sdk_3_0_100_P5_X64,
-                    Sdk_2_1_300_Rc1_X86,
-                    Runtime_3_0_0_P5_X64,
-                    Runtime_3_0_0_P5_X86,
-                    Runtime_2_1_0_Rc1_X64
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                BundleArch.X64 | BundleArch.X86
             };
         }
 

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/FiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/FiltererTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     public abstract class FiltererTests
     {
         internal abstract Option Option { get; }
-        internal abstract string DefaultArgValue { get; }
+        internal abstract string DefaultTestArgValue { get; }
         internal virtual Filterer OptionFilterer => OptionFilterers.OptionFiltererDictionary[Option];
 
         internal const BundleArch DefaultTestArchSelection = BundleArch.Arm32 | BundleArch.X86 | BundleArch.X64;
@@ -72,13 +72,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         [InlineData((BundleType.Sdk | BundleType.Runtime) + 10)]
         internal void TestFiltererArgumentOutOfRangeException(BundleType typeSelection)
         {
-            TestFiltererException<ArgumentOutOfRangeException>(DefaultTestBundles, DefaultArgValue, typeSelection, DefaultTestArchSelection);
+            TestFiltererException<ArgumentOutOfRangeException>(DefaultTestBundles, DefaultTestArgValue, typeSelection, DefaultTestArchSelection);
         }
 
         [Fact]
         internal void TestFiltererBundleTypeNotSpecifiedException()
         {
-            TestFiltererException<BundleTypeMissingException>(DefaultTestBundles, DefaultArgValue, BundleType.Sdk | BundleType.Runtime, DefaultTestArchSelection);
+            TestFiltererException<BundleTypeMissingException>(DefaultTestBundles, DefaultTestArgValue, BundleType.Sdk | BundleType.Runtime, DefaultTestArchSelection);
         }
 
         internal virtual void TestFiltererGood(IEnumerable<Bundle> testBundles, string argValue, IEnumerable<Bundle> expected, BundleType typeSelection, BundleArch archSelection)

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/FiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/FiltererTests.cs
@@ -15,7 +15,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal abstract Option Option { get; }
         internal abstract string DefaultArgValue { get; }
-        internal abstract bool TestBundleTypeNotSpecifiedException { get; }
         internal virtual Filterer OptionFilterer => OptionFilterers.OptionFiltererDictionary[Option];
 
         internal const BundleArch DefaultTestArchSelection = BundleArch.Arm32 | BundleArch.X86 | BundleArch.X64;
@@ -79,10 +78,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         [Fact]
         internal void TestFiltererBundleTypeNotSpecifiedException()
         {
-            if (TestBundleTypeNotSpecifiedException)
-            {
-                TestFiltererException<BundleTypeMissingException>(DefaultTestBundles, DefaultArgValue, BundleType.Sdk | BundleType.Runtime, DefaultTestArchSelection);
-            }
+            TestFiltererException<BundleTypeMissingException>(DefaultTestBundles, DefaultArgValue, BundleType.Sdk | BundleType.Runtime, DefaultTestArchSelection);
         }
 
         internal virtual void TestFiltererGood(IEnumerable<Bundle> testBundles, string argValue, IEnumerable<Bundle> expected, BundleType typeSelection, BundleArch archSelection)

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/MajorMinorOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/MajorMinorOptionFiltererTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     public class MajorMinorOptionFiltererTests : FiltererTests
     {
         internal override Option Option => CommandLineConfigs.UninstallMajorMinorOption;
-        internal override string DefaultArgValue => "2.2";
+        internal override string DefaultTestArgValue => "2.2";
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/MajorMinorOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/MajorMinorOptionFiltererTests.cs
@@ -11,7 +11,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal override Option Option => CommandLineConfigs.UninstallMajorMinorOption;
         internal override string DefaultArgValue => "2.2";
-        internal override bool TestBundleTypeNotSpecifiedException => false;
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()
         {
@@ -47,40 +46,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
             yield return new object[]
             {
                 DefaultTestBundles,
-                "2.1",
-                new List<Bundle>
-                {
-                    Sdk_2_1_700_X64,
-                    Sdk_2_1_300_Rc1_Arm32,
-                    Sdk_2_1_300_Rc1_X86,
-                    Runtime_2_1_0_Rc1_X64
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                DefaultTestArchSelection
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                "2.2",
-                new List<Bundle>
-                {
-                    Sdk_2_2_300_X64,
-                    Sdk_2_2_222_X86,
-                    Sdk_2_2_202_X86,
-                    Sdk_2_2_202_Arm32,
-                    Runtime_2_2_5_Arm32,
-                    Runtime_2_2_5_X86,
-                    Runtime_2_2_4_X86,
-                    Runtime_2_2_2_X64
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                DefaultTestArchSelection
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
                 "2.5",
                 new List<Bundle>(),
                 BundleType.Sdk,
@@ -93,15 +58,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 "2.5",
                 new List<Bundle>(),
                 BundleType.Runtime,
-                DefaultTestArchSelection
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                "2.5",
-                new List<Bundle>(),
-                BundleType.Sdk | BundleType.Runtime,
                 DefaultTestArchSelection
             };
 
@@ -133,34 +89,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
             yield return new object[]
             {
                 DefaultTestBundles,
-                "2.1",
-                new List<Bundle>
-                {
-                    Sdk_2_1_700_X64,
-                    Runtime_2_1_0_Rc1_X64
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                BundleArch.X64
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                "2.2",
-                new List<Bundle>
-                {
-                    Sdk_2_2_300_X64,
-                    Sdk_2_2_202_Arm32,
-                    Runtime_2_2_5_Arm32,
-                    Runtime_2_2_2_X64
-                },
-                BundleType.Sdk | BundleType.Runtime,
-                BundleArch.X64 | BundleArch.Arm32
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
                 "2.5",
                 new List<Bundle>(),
                 BundleType.Sdk,
@@ -174,15 +102,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
                 new List<Bundle>(),
                 BundleType.Runtime,
                 BundleArch.X64 | BundleArch.X86
-            };
-
-            yield return new object[]
-            {
-                DefaultTestBundles,
-                "2.5",
-                new List<Bundle>(),
-                BundleType.Sdk | BundleType.Runtime,
-                BundleArch.X86 | BundleArch.Arm32
             };
         }
 
@@ -208,7 +127,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         [InlineData("3.0.100-preview5-011568")]
         internal void TestMajorMinorOptionFiltererInvalidInputVersionStringException(string argValue)
         {
-            TestFiltererException<InvalidInputVersionException>(DefaultTestBundles, argValue, BundleType.Sdk | BundleType.Runtime, DefaultTestArchSelection);
+            TestFiltererException<InvalidInputVersionException>(DefaultTestBundles, argValue, BundleType.Sdk, DefaultTestArchSelection);
+            TestFiltererException<InvalidInputVersionException>(DefaultTestBundles, argValue, BundleType.Runtime, DefaultTestArchSelection);
         }
     }
 }

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/NoOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/NoOptionFiltererTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal override Option Option => null;
         internal override string DefaultArgValue => "2.2.5";
-        internal override bool TestBundleTypeNotSpecifiedException => true;
         internal override Filterer OptionFilterer => OptionFilterers.UninstallNoOptionFilterer;
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/NoOptionFiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/NoOptionFiltererTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     public class NoOptionFiltererTests : FiltererTests
     {
         internal override Option Option => null;
-        internal override string DefaultArgValue => "2.2.5";
+        internal override string DefaultTestArgValue => "2.2.5";
         internal override Filterer OptionFilterer => OptionFilterers.UninstallNoOptionFilterer;
 
         public static IEnumerable<object[]> GetDataForTestFiltererGood()


### PR DESCRIPTION
Having had several offline conversations with @KathleenDollard, we eventually decide not to allow the `--sdk` option and the `--runtime` option to occur simultaneously, even for the options that do not have ambiguities between SDK versions and Runtime versions, such as `--all` and `--major-minor`.

The reason for this decision is that it will otherwise be very difficult to deliver the information about which options require exactly one of `--sdk` and `--runtime` and which don't. This will be extremely hard to the help information.