### PR TITLE
WIP `FileSystemExplorer` for `list` command on macOS

### DIFF
--- a/src/dotnet-uninstall/MacOs/FileSystemExplorer.cs
+++ b/src/dotnet-uninstall/MacOs/FileSystemExplorer.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
+
+namespace Microsoft.DotNet.Tools.Uninstall.MacOs
+{
+    internal static class FileSystemExplorer
+    {
+        private static readonly string DotNetInstallPath = Path.Combine("/", "usr", "local", "share", "dotnet");
+        private static readonly string DotNetSdkInstallPath = Path.Combine(DotNetInstallPath, "sdk");
+        private static readonly string DotNetRuntimeInstallPath = Path.Combine(DotNetInstallPath, "shared", "Microsoft.NETCore.App");
+
+        public static IEnumerable<Bundle> GetInstalledBundles()
+        {
+            var sdks = GetInstalledBundles<SdkVersion>(DotNetSdkInstallPath);
+            var runtimes = GetInstalledBundles<RuntimeVersion>(DotNetRuntimeInstallPath);
+
+            return sdks.Concat(runtimes);
+        }
+
+        private static IEnumerable<Bundle> GetInstalledBundles<TBundleVersion>(string path)
+            where TBundleVersion : BundleVersion, new()
+        {
+            return new DirectoryInfo(path)
+                .EnumerateDirectories()
+                .Select(dirInfo =>
+                {
+                    var success = BundleVersion.TryFromInput<TBundleVersion>(dirInfo.Name, out var version);
+                    return (success, version, path: dirInfo.FullName);
+                })
+                .Where(tuple => tuple.success)
+                .Select(tuple => Bundle<SdkVersion>.From(tuple.version, BundleArch.X64, GetUninstallCommand(tuple.path)));
+        }
+
+        private static string GetUninstallCommand(string path)
+        {
+            return $"sudo rm -rf {path}";
+        }
+    }
+}

--- a/src/dotnet-uninstall/Shared/BundleInfo/Versioning/BundleVersion.cs
+++ b/src/dotnet-uninstall/Shared/BundleInfo/Versioning/BundleVersion.cs
@@ -10,29 +10,29 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
         public abstract BundleType Type { get; }
         public abstract BeforePatch BeforePatch { get; }
 
-        protected readonly SemanticVersion _semVer;
+        protected SemanticVersion SemVer { get; private set; }
 
-        public virtual int Major => _semVer.Major;
-        public virtual int Minor => _semVer.Minor;
-        public virtual int Patch => _semVer.Patch;
-        public virtual bool IsPrerelease => _semVer.IsPrerelease;
+        public virtual int Major => SemVer.Major;
+        public virtual int Minor => SemVer.Minor;
+        public virtual int Patch => SemVer.Patch;
+        public virtual bool IsPrerelease => SemVer.IsPrerelease;
         public virtual MajorMinorVersion MajorMinor => new MajorMinorVersion(Major, Minor);
+
+        protected BundleVersion()
+        {
+            SemVer = null;
+        }
 
         public BundleVersion(string value)
         {
-            if (SemanticVersion.TryParse(value, out var version))
+            if (SemanticVersion.TryParse(value, out var semVer))
             {
-                _semVer = version;
+                SemVer = semVer;
             }
             else
             {
                 throw new InvalidInputVersionException(value);
             }
-        }
-
-        public override string ToString()
-        {
-            return _semVer.ToString();
         }
 
         public static BundleVersion FromInput<TBundleVersion>(string value)
@@ -51,6 +51,27 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
             throw new ArgumentException();
         }
 
+        public static bool TryFromInput<TBundleVersion>(string value, out TBundleVersion version)
+            where TBundleVersion : BundleVersion, new()
+        {
+            if (SemanticVersion.TryParse(value, out var semVer))
+            {
+                version = new TBundleVersion
+                {
+                    SemVer = semVer
+                };
+                return true;
+            }
+
+            version = null;
+            return false;
+        }
+
+        public override string ToString()
+        {
+            return SemVer.ToString();
+        }
+
         public override bool Equals(object obj)
         {
             return Equals(obj as BundleVersion);
@@ -59,12 +80,12 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
         public bool Equals(BundleVersion other)
         {
             return other != null &&
-                   EqualityComparer<SemanticVersion>.Default.Equals(_semVer, other._semVer);
+                   EqualityComparer<SemanticVersion>.Default.Equals(SemVer, other.SemVer);
         }
 
         public override int GetHashCode()
         {
-            return HashCode.Combine(_semVer);
+            return HashCode.Combine(SemVer);
         }
     }
 }

--- a/src/dotnet-uninstall/Shared/BundleInfo/Versioning/RuntimeVersion.cs
+++ b/src/dotnet-uninstall/Shared/BundleInfo/Versioning/RuntimeVersion.cs
@@ -7,6 +7,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
         public override BundleType Type => BundleType.Runtime;
         public override BeforePatch BeforePatch => new MajorMinorVersion(Major, Minor);
 
+        public RuntimeVersion() { }
+
         public RuntimeVersion(string value) : base(value) { }
 
         public int CompareTo(object obj)
@@ -16,7 +18,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
 
         public int CompareTo(RuntimeVersion other)
         {
-            return other == null ? 1 : _semVer.CompareTo(other._semVer);
+            return other == null ? 1 : SemVer.CompareTo(other.SemVer);
         }
 
         public override bool Equals(object obj)

--- a/src/dotnet-uninstall/Shared/BundleInfo/Versioning/SdkVersion.cs
+++ b/src/dotnet-uninstall/Shared/BundleInfo/Versioning/SdkVersion.cs
@@ -4,11 +4,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
 {
     internal class SdkVersion : BundleVersion, IComparable, IComparable<SdkVersion>, IEquatable<SdkVersion>
     {
-        public int SdkMinor => _semVer.Patch / 100;
-        public override int Patch => _semVer.Patch % 100;
+        public int SdkMinor => SemVer.Patch / 100;
+        public override int Patch => SemVer.Patch % 100;
         public override BeforePatch BeforePatch => new MajorMinorSdkMinorVersion(Major, Minor, SdkMinor);
 
         public override BundleType Type => BundleType.Sdk;
+
+        public SdkVersion() { }
 
         public SdkVersion(string value) : base(value) { }
 
@@ -19,7 +21,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
 
         public int CompareTo(SdkVersion other)
         {
-            return other == null ? 1 : _semVer.CompareTo(other._semVer);
+            return other == null ? 1 : SemVer.CompareTo(other.SemVer);
         }
 
         public override bool Equals(object obj)

--- a/src/dotnet-uninstall/Shared/Commands/ListCommandExec.cs
+++ b/src/dotnet-uninstall/Shared/Commands/ListCommandExec.cs
@@ -4,6 +4,7 @@ using System.CommandLine;
 using System.CommandLine.Rendering;
 using System.CommandLine.Rendering.Views;
 using System.Linq;
+using Microsoft.DotNet.Tools.Uninstall.MacOs;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Configs;
@@ -23,7 +24,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             }
             else if (RuntimeInfo.RunningOnOSX)
             {
-                throw new NotImplementedException();
+                Execute(FileSystemExplorer.GetInstalledBundles());
             }
             else if (RuntimeInfo.RunningOnLinux)
             {

--- a/src/dotnet-uninstall/dotnet-uninstall.csproj
+++ b/src/dotnet-uninstall/dotnet-uninstall.csproj
@@ -46,4 +46,7 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="MacOs\" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
The reason for which `BundleVersion.SemVer` is no longer `readonly` is that C# allows generic type parameters to call `public` zero-argument constructors only.