### PR TITLE
Refactoring of `BundleVersion.FromInput` & constructors of `SdkVersion` and `RuntimeVersion`

### DIFF
--- a/src/dotnet-uninstall/Shared/BundleInfo/Versioning/RuntimeVersion.cs
+++ b/src/dotnet-uninstall/Shared/BundleInfo/Versioning/RuntimeVersion.cs
@@ -7,6 +7,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
         public override BundleType Type => BundleType.Runtime;
         public override BeforePatch BeforePatch => new MajorMinorVersion(Major, Minor);
 
+        public RuntimeVersion() { }
+
         public RuntimeVersion(string value) : base(value) { }
 
         public int CompareTo(object obj)
@@ -16,7 +18,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
 
         public int CompareTo(RuntimeVersion other)
         {
-            return other == null ? 1 : _semVer.CompareTo(other._semVer);
+            return other == null ? 1 : SemVer.CompareTo(other.SemVer);
         }
 
         public override bool Equals(object obj)

--- a/src/dotnet-uninstall/Shared/BundleInfo/Versioning/SdkVersion.cs
+++ b/src/dotnet-uninstall/Shared/BundleInfo/Versioning/SdkVersion.cs
@@ -4,11 +4,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
 {
     internal class SdkVersion : BundleVersion, IComparable, IComparable<SdkVersion>, IEquatable<SdkVersion>
     {
-        public int SdkMinor => _semVer.Patch / 100;
-        public override int Patch => _semVer.Patch % 100;
+        public int SdkMinor => SemVer.Patch / 100;
+        public override int Patch => SemVer.Patch % 100;
         public override BeforePatch BeforePatch => new MajorMinorSdkMinorVersion(Major, Minor, SdkMinor);
 
         public override BundleType Type => BundleType.Sdk;
+
+        public SdkVersion() { }
 
         public SdkVersion(string value) : base(value) { }
 
@@ -19,7 +21,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
 
         public int CompareTo(SdkVersion other)
         {
-            return other == null ? 1 : _semVer.CompareTo(other._semVer);
+            return other == null ? 1 : SemVer.CompareTo(other.SemVer);
         }
 
         public override bool Equals(object obj)

--- a/src/dotnet-uninstall/Shared/Filterers/Filterer.cs
+++ b/src/dotnet-uninstall/Shared/Filterers/Filterer.cs
@@ -55,7 +55,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Filterers
         }
 
         public abstract IEnumerable<Bundle<TBundleVersion>> Filter<TBundleVersion>(TArg argValue, IEnumerable<Bundle<TBundleVersion>> bundles)
-            where TBundleVersion : BundleVersion, IComparable<TBundleVersion>;
+            where TBundleVersion : BundleVersion, IComparable<TBundleVersion>, new();
     }
 
     internal abstract class NoArgFilterer : Filterer

--- a/test/dotnet-uninstall.Tests/Shared/BundleInfo/Versioning/RuntimeVersionTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/BundleInfo/Versioning/RuntimeVersionTests.cs
@@ -17,8 +17,12 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.BundleInfo.Versioning
         [InlineData("3.0.1-rc1-final", 3, 0, 1, true)]
         internal void TestConstructor(string input, int major, int minor, int patch, bool isPrerelease)
         {
-            var version = new RuntimeVersion(input);
+            TestProperties(new RuntimeVersion(input), major, minor, patch, isPrerelease);
+            TestProperties(BundleVersion.FromInput<RuntimeVersion>(input), major, minor, patch, isPrerelease);
+        }
 
+        private static void TestProperties(RuntimeVersion version, int major, int minor, int patch, bool isPrerelease)
+        {
             version.Major.Should().Be(major);
             version.Minor.Should().Be(minor);
             version.Patch.Should().Be(patch);

--- a/test/dotnet-uninstall.Tests/Shared/BundleInfo/Versioning/SdkVersionTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/BundleInfo/Versioning/SdkVersionTests.cs
@@ -19,8 +19,12 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.BundleInfo.Versioning
         [InlineData("2.0.2-rc1-abcdef", 2, 0, 0, 2, true)]
         internal void TestConstructor(string input, int major, int minor, int sdkMinor, int patch, bool isPrerelease)
         {
-            var version = new SdkVersion(input);
+            TestProperties(new SdkVersion(input), major, minor, sdkMinor, patch, isPrerelease);
+            TestProperties(BundleVersion.FromInput<SdkVersion>(input), major, minor, sdkMinor, patch, isPrerelease);
+        }
 
+        private static void TestProperties(SdkVersion version, int major, int minor, int sdkMinor, int patch, bool isPrerelease)
+        {
             version.Major.Should().Be(major);
             version.Minor.Should().Be(minor);
             version.SdkMinor.Should().Be(sdkMinor);

--- a/test/dotnet-uninstall.Tests/Shared/Filterers/FiltererTests.cs
+++ b/test/dotnet-uninstall.Tests/Shared/Filterers/FiltererTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         }
 
         private static Bundle<TBundleVersion> GetBundleFromInput<TBundleVersion>(string input, BundleArch arch)
-            where TBundleVersion : BundleVersion, IComparable<TBundleVersion>
+            where TBundleVersion : BundleVersion, IComparable<TBundleVersion>, new()
         {
             return Bundle.From(BundleVersion.FromInput<TBundleVersion>(input), arch, input) as Bundle<TBundleVersion>;
         }


### PR DESCRIPTION
From my point of view, this pull request provides a better workaround to address the issue brought up [here](https://github.com/dotnet/cli-lab/pull/22#discussion_r297475584).

I split Pull Request #28 to make it independent of macOS implementations. Hence it can be reviewed separately. Pull Request #28 has been closed.