### PR TITLE
`list` command for macOS

### DIFF
--- a/src/dotnet-uninstall/MacOs/ListCommandExec.cs
+++ b/src/dotnet-uninstall/MacOs/ListCommandExec.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine.Rendering.Views;
+using System.Linq;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
+
+namespace Microsoft.DotNet.Tools.Uninstall.MacOs
+{
+    internal static class ListCommandExec
+    {
+        public static GridView GetGridView(IList<Bundle> bundles)
+        {
+            var gridView = new GridView();
+
+            gridView.SetColumns(Enumerable.Repeat(ColumnDefinition.SizeToContent(), 3).ToArray());
+            gridView.SetRows(Enumerable.Repeat(RowDefinition.SizeToContent(), Math.Max(bundles.Count, 1)).ToArray());
+
+            foreach (var (bundle, index) in bundles.Select((bundle, index) => (bundle, index)))
+            {
+                gridView.SetChild(new ContentView(string.Empty), 0, index);
+                gridView.SetChild(new ContentView(bundle.Version.ToString()), 1, index);
+                gridView.SetChild(new ContentView($"({bundle.Arch.ToString().ToLower()})"), 2, index);
+            }
+
+            return gridView;
+        }
+    }
+}

--- a/src/dotnet-uninstall/MacOs/ListCommandExec.cs
+++ b/src/dotnet-uninstall/MacOs/ListCommandExec.cs
@@ -3,11 +3,20 @@ using System.Collections.Generic;
 using System.CommandLine.Rendering.Views;
 using System.Linq;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Commands;
 
 namespace Microsoft.DotNet.Tools.Uninstall.MacOs
 {
     internal static class ListCommandExec
     {
+        public static readonly IEnumerable<BundleTypePrintInfo> SupportedBundleTypes =
+            new BundleTypePrintInfo[]
+            {
+                new BundleTypePrintInfo<SdkVersion>(LocalizableStrings.ListCommandSdkHeader),
+                new BundleTypePrintInfo<RuntimeVersion>(LocalizableStrings.ListCommandRuntimeHeader)
+            };
+
         public static GridView GetGridView(IList<Bundle> bundles)
         {
             var gridView = new GridView();

--- a/src/dotnet-uninstall/Shared/Commands/BundleTypePrintInfo.cs
+++ b/src/dotnet-uninstall/Shared/Commands/BundleTypePrintInfo.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
+
+namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
+{
+    internal abstract class BundleTypePrintInfo
+    {
+        public abstract BundleType Type { get; }
+
+        public string Header { get; }
+
+        protected BundleTypePrintInfo(string header)
+        {
+            Header = header ?? throw new ArgumentNullException();
+        }
+
+        public abstract IEnumerable<Bundle> Filter(IEnumerable<Bundle> bundles);
+    }
+
+    internal class BundleTypePrintInfo<TBundleVersion> : BundleTypePrintInfo
+        where TBundleVersion : BundleVersion, IComparable<TBundleVersion>, new()
+    {
+        public override BundleType Type => new TBundleVersion().Type;
+
+        public BundleTypePrintInfo(string header) : base(header) { }
+
+        public override IEnumerable<Bundle> Filter(IEnumerable<Bundle> bundles)
+        {
+            return Bundle<TBundleVersion>.FilterWithSameBundleType(bundles);
+        }
+    }
+}

--- a/src/dotnet-uninstall/Windows/ListCommandExec.cs
+++ b/src/dotnet-uninstall/Windows/ListCommandExec.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine.Rendering.Views;
+using System.Linq;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
+
+namespace Microsoft.DotNet.Tools.Uninstall.Windows
+{
+    internal static class ListCommandExec
+    {
+        public static GridView GetGridView(IList<Bundle> bundles)
+        {
+            var gridView = new GridView();
+
+            gridView.SetColumns(Enumerable.Repeat(ColumnDefinition.SizeToContent(), 3).ToArray());
+            gridView.SetRows(Enumerable.Repeat(RowDefinition.SizeToContent(), Math.Max(bundles.Count, 1)).ToArray());
+
+            foreach (var (bundle, index) in bundles.Select((bundle, index) => (bundle, index)))
+            {
+                gridView.SetChild(new ContentView(string.Empty), 0, index);
+                gridView.SetChild(new ContentView(bundle.Version.ToString()), 1, index);
+                gridView.SetChild(new ContentView($"\"{bundle.DisplayName}\""), 2, index);
+            }
+
+            return gridView;
+        }
+    }
+}

--- a/src/dotnet-uninstall/Windows/ListCommandExec.cs
+++ b/src/dotnet-uninstall/Windows/ListCommandExec.cs
@@ -3,11 +3,20 @@ using System.Collections.Generic;
 using System.CommandLine.Rendering.Views;
 using System.Linq;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Commands;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Windows
 {
     internal static class ListCommandExec
     {
+        public static readonly IEnumerable<BundleTypePrintInfo> SupportedBundleTypes =
+            new BundleTypePrintInfo[]
+            {
+                new BundleTypePrintInfo<SdkVersion>(LocalizableStrings.ListCommandSdkHeader),
+                new BundleTypePrintInfo<RuntimeVersion>(LocalizableStrings.ListCommandRuntimeHeader)
+            };
+
         public static GridView GetGridView(IList<Bundle> bundles)
         {
             var gridView = new GridView();


### PR DESCRIPTION
Implemented the `list` command for macOS:
1. Added `ListCommandExec` for Windows and for macOS to abstract code that is common to both platforms.
2. Added `FileSystemExplorer` to access the bundle information installed on macOS.
3. Added `BundleTypePrintInfo` for future support of ASP.NET bundles.