### PR TITLE
Uninstallation timeout

### DIFF
--- a/src/dotnet-uninstall/Windows/UninstallCommandExec.cs
+++ b/src/dotnet-uninstall/Windows/UninstallCommandExec.cs
@@ -10,16 +10,16 @@ using Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Windows
 {
-    public static class UninstallCommandExec
+    internal static class UninstallCommandExec
     {
         private const int UNINSTALL_TIMEOUT = 10 * 60 * 1000;
 
         [DllImport("shell32.dll", SetLastError = true)]
-        internal static extern IntPtr CommandLineToArgvW(
+        private static extern IntPtr CommandLineToArgvW(
             [MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine,
             out int pNumArgs);
 
-        internal static void ExecuteUninstallCommand(IEnumerable<Bundle> bundles)
+        public static void ExecuteUninstallCommand(IEnumerable<Bundle> bundles)
         {
             if (!IsAdmin())
             {

--- a/src/dotnet-uninstall/Windows/UninstallCommandExec.cs
+++ b/src/dotnet-uninstall/Windows/UninstallCommandExec.cs
@@ -15,7 +15,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Windows
         private const int UNINSTALL_TIMEOUT = 10 * 60 * 1000;
 
         [DllImport("shell32.dll", SetLastError = true)]
-        static extern IntPtr CommandLineToArgvW(
+        internal static extern IntPtr CommandLineToArgvW(
             [MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine,
             out int pNumArgs);
 

--- a/src/dotnet-uninstall/Windows/UninstallCommandExec.cs
+++ b/src/dotnet-uninstall/Windows/UninstallCommandExec.cs
@@ -12,7 +12,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Windows
 {
     public static class UninstallCommandExec
     {
-        private const int UNINSTALL_TIMEOUT = 5 * 60 * 1000;
+        private const int UNINSTALL_TIMEOUT = 10 * 60 * 1000;
 
         [DllImport("shell32.dll", SetLastError = true)]
         static extern IntPtr CommandLineToArgvW(


### PR DESCRIPTION
As discussed in a previous offline meeting with @KathleenDollard and @wli3, the uninstallation timeout is set to 10 minutes instead of 5 minutes.

Also fixed some visibility modifiers of the `Windows.UninstallCommandExec` class.