### PR TITLE
`Ctrl-C` handler

### DIFF
--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -70,6 +70,15 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Canceling: waiting for the current uninstall to complete..
+        /// </summary>
+        internal static string CancelingMessage {
+            get {
+                return ResourceManager.GetString("CancelingMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Actually uninstall specified .NET Core SDKs or Runtimes..
         /// </summary>
         internal static string DoItOptionDescription {

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -246,4 +246,7 @@
   <data name="MacOsBundleDisplayNameFormat" xml:space="preserve">
     <value>Microsoft .NET Core {0} {1} (x64)</value>
   </data>
+  <data name="CancelingMessage" xml:space="preserve">
+    <value>Canceling: waiting for the current uninstall to complete.</value>
+  </data>
 </root>

--- a/src/dotnet-core-uninstall/Program.cs
+++ b/src/dotnet-core-uninstall/Program.cs
@@ -11,7 +11,6 @@ namespace Microsoft.DotNet.Tools.Uninstall
     {
         internal static int Main(string[] args)
         {
-            Console.CancelKeyPress += new ConsoleCancelEventHandler((sender, cancelArgs) => cancelArgs.Cancel = true);
             return CommandLineConfigs.UninstallRootCommand.InvokeAsync(args).Result;
         }
     }

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -7,6 +7,11 @@
         <target state="new">You must specify either --sdk or --runtime.</target>
         <note />
       </trans-unit>
+      <trans-unit id="CancelingMessage">
+        <source>Canceling: waiting for the current uninstall to complete.</source>
+        <target state="new">Canceling: waiting for the current uninstall to complete.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="DoItOptionDescription">
         <source>Actually uninstall specified .NET Core SDKs or Runtimes.</source>
         <target state="new">Actually uninstall specified .NET Core SDKs or Runtimes.</target>


### PR DESCRIPTION
The current behavior of the `Ctrl-C` handler is to wait for the current uninstall to complete.

We may want to change the behavior to canceling the current uninstall. However this would be complicated and we can do that in a separate PR.