### PR TITLE
Dry run do-it command fix

### DIFF
--- a/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
@@ -7,6 +7,8 @@ using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
 using Microsoft.DotNet.Tools.Uninstall.Windows;
 using System.Reflection;
 using Microsoft.DotNet.Tools.Uninstall.MacOs;
+using System.Linq;
+using System.Diagnostics;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
 {
@@ -108,7 +110,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             Console.WriteLine();
             Console.WriteLine(string.Format(
                 LocalizableStrings.DryRunHowToDoItMessageFormat,
-                string.Join(" ", Environment.GetCommandLineArgs())));
+                $"{Process.GetCurrentProcess().MainModule.FileName} {string.Join(" ", Environment.GetCommandLineArgs().Skip(1))}"));
         }
 
         private static void HandleVersionOption()

--- a/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
@@ -9,6 +9,7 @@ using System.Reflection;
 using Microsoft.DotNet.Tools.Uninstall.MacOs;
 using System.Linq;
 using System.Diagnostics;
+using System.IO;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
 {
@@ -110,7 +111,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             Console.WriteLine();
             Console.WriteLine(string.Format(
                 LocalizableStrings.DryRunHowToDoItMessageFormat,
-                $"{Process.GetCurrentProcess().MainModule.FileName} {string.Join(" ", Environment.GetCommandLineArgs().Skip(1))}"));
+                $"{Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName)} {string.Join(" ", Environment.GetCommandLineArgs().Skip(1))}"));
         }
 
         private static void HandleVersionOption()


### PR DESCRIPTION
Before:
```
*** DRY RUN
Would uninstall: .NET Core SDK 1.1.14 (x64).
*** END DRY RUN

To actually uninstall, add --do-it: C:\Users\t-yup\github\cli-lab\artifacts\bin\dotnet-core-uninstall\Release\netcoreapp2.1\win-x64\publish\dotnet-core-uninstall.dll--major-minor 1.1 --sdk --do-it.
```

After:
```
*** DRY RUN
Would uninstall: .NET Core SDK 1.1.14 (x64).
*** END DRY RUN

To actually uninstall, add --do-it: C:\Users\t-yup\github\cli-lab\artifacts\bin\dotnet-core-uninstall\Release\netcoreapp2.1\win-x64\publish\dotnet-core-uninstall.exe --major-minor 1.1 --sdk --do-it.
```