### PR TITLE
`System.CommandLine` upgrade

### DIFF
--- a/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
@@ -69,16 +69,25 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
 
             if (option == null)
             {
-                if (CommandLineConfigs.CommandLineParseResult.RootCommandResult.Arguments.Count == 0)
+                if (CommandLineConfigs.CommandLineParseResult.RootCommandResult.Tokens.Count == 0)
                 {
                     throw new RequiredArgMissingForUninstallCommandException();
                 }
 
-                return OptionFilterers.UninstallNoOptionFilterer.Filter(CommandLineConfigs.CommandLineParseResult.RootCommandResult.Arguments, bundles, typeSelection, archSelection);
+                return OptionFilterers.UninstallNoOptionFilterer.Filter(
+                    CommandLineConfigs.CommandLineParseResult.RootCommandResult.Tokens.Select(t => t.Value),
+                    bundles,
+                    typeSelection,
+                    archSelection);
             }
             else
             {
-                return OptionFilterers.OptionFiltererDictionary[option].Filter(CommandLineConfigs.CommandLineParseResult, option, bundles, typeSelection, archSelection);
+                return OptionFilterers.OptionFiltererDictionary[option].Filter(
+                    CommandLineConfigs.CommandLineParseResult,
+                    option,
+                    bundles,
+                    typeSelection,
+                    archSelection);
             }
         }
 

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -26,19 +26,23 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
         public static readonly Option UninstallAllButOption = new Option(
             "--all-but",
-            LocalizableStrings.UninstallAllButOptionDescription,
-            new Argument<IEnumerable<string>>
+            LocalizableStrings.UninstallAllButOptionDescription)
+        {
+            Argument = new Argument<IEnumerable<string>>
             {
                 Name = LocalizableStrings.UninstallAllButOptionArgumentName
-            });
+            }
+        };
 
         public static readonly Option UninstallAllBelowOption = new Option(
             "--all-below",
-            LocalizableStrings.UninstallAllBelowOptionDescription,
-            new Argument<string>
+            LocalizableStrings.UninstallAllBelowOptionDescription)
+        {
+            Argument = new Argument<string>
             {
                 Name = LocalizableStrings.UninstallAllBelowOptionArgumentName
-            });
+            }
+        };
 
         public static readonly Option UninstallAllPreviewsOption = new Option(
             "--all-previews",
@@ -50,19 +54,23 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
         public static readonly Option UninstallMajorMinorOption = new Option(
             "--major-minor",
-            LocalizableStrings.UninstallMajorMinorOptionDescription,
-            new Argument<string>
+            LocalizableStrings.UninstallMajorMinorOptionDescription)
+        {
+            Argument = new Argument<string>
             {
                 Name = LocalizableStrings.UninstallMajorMinorOptionArgumentName
-            });
+            }
+        };
 
         public static readonly Option UninstallVerbosityOption = new Option(
             new[] { "--verbosity", "-v" },
-            LocalizableStrings.UninstallVerbosityOptionDescription,
-            new Argument<string>
+            LocalizableStrings.UninstallVerbosityOptionDescription)
+        {
+            Argument = new Argument<string>
             {
                 Name = LocalizableStrings.UninstallVerbosityOptionArgumentName
-            });
+            }
+        };
 
         public static readonly Option SdkOption = new Option(
             "--sdk",
@@ -85,8 +93,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             LocalizableStrings.X64OptionDescription);
 
         public static readonly Option VersionOption = new Option(
-            "--version",
-            isHidden: true);
+            "--version");
 
         public static readonly Option DoItOption = new Option(
             "--do-it",
@@ -115,12 +122,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
         };
 
         public static readonly RootCommand UninstallRootCommand = new RootCommand(
-            LocalizableStrings.UninstallNoOptionDescription,
-            argument: new Argument<IEnumerable<string>>
-            {
-                Name = LocalizableStrings.UninstallNoOptionArgumentName,
-                Description = LocalizableStrings.UninstallNoOptionArgumentDescription
-            });
+            LocalizableStrings.UninstallNoOptionDescription);
 
         public static readonly Command ListCommand = new Command(
             "list",
@@ -139,7 +141,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
         static CommandLineConfigs()
         {
-            UninstallRootCommand.Add(ListCommand);
+            UninstallRootCommand.AddArgument(new Argument<IEnumerable<string>>
+            {
+                Name = LocalizableStrings.UninstallNoOptionArgumentName,
+                Description = LocalizableStrings.UninstallNoOptionArgumentDescription
+            });
+
+            UninstallRootCommand.AddCommand(ListCommand);
 
             foreach (var option in UninstallMainOptions
                 .Concat(AuxOptions)
@@ -153,7 +161,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             foreach (var option in AuxOptions
                 .OrderBy(option => option.Name))
             {
-                ListCommand.Add(option);
+                ListCommand.AddOption(option);
             }
 
             ListCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => ListCommandExec.Execute()));

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -182,7 +182,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
             var specifiedOption = specified.FirstOrDefault();
 
-            if (specifiedOption != null && commandResult.Arguments.Count > 0)
+            if (specifiedOption != null && commandResult.Tokens.Count > 0)
             {
                 var optionName = $"--{specifiedOption.Name}";
 

--- a/src/dotnet-core-uninstall/dotnet-core-uninstall.csproj
+++ b/src/dotnet-core-uninstall/dotnet-core-uninstall.csproj
@@ -16,8 +16,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
     <PackageReference Include="NuGet.Versioning" Version="5.1.0" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.2.0-alpha.19174.3" />
-    <PackageReference Include="System.CommandLine.Rendering" Version="0.2.0-alpha.19174.3" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19317.1" />
+    <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.19317.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
 
             parseResult.CommandResult.Name.Should().Be("list");
-            parseResult.CommandResult.Arguments.Should().BeEmpty();
+            parseResult.CommandResult.Tokens.Should().BeEmpty();
 
             parseResult.Errors.Should().BeEmpty();
             parseResult.UnparsedTokens.Should().BeEmpty();
@@ -97,7 +97,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             }
             else
             {
-                parseResult.RootCommandResult.Arguments.As<object>().Should().BeEquivalentTo(expected);
+                parseResult.RootCommandResult.Tokens.Select(t => t.Value).As<object>()
+                    .Should().BeEquivalentTo(expected);
             }
 
             parseResult.Errors.Should().BeEmpty();

--- a/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
@@ -405,8 +405,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("list -v diag", VerbosityLevel.Diagnostic)]
         [InlineData("list -v diagnostic", VerbosityLevel.Diagnostic)]
         [InlineData("-v q list", VerbosityLevel.Normal)]
-        [InlineData("-v m list -v d", VerbosityLevel.Detailed)]
-        [InlineData("-v unknown list -v d", VerbosityLevel.Detailed)]
+        [InlineData("list -v d", VerbosityLevel.Detailed)]
         internal void TestGetVerbosityLevel(string command, VerbosityLevel expected)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
@@ -426,8 +425,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("list -v qu")]
         [InlineData("list --verbosity mini")]
         [InlineData("list -v unknown")]
-        [InlineData("-v q list -v unknown")]
-        [InlineData("-v mini list -v unknown")]
         internal void TestGetVerbosityLevelVerbosityLevelInvalidException(string command)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);

--- a/test/dotnet-core-uninstall.Tests/Shared/Filterers/NoOptionFiltererTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Filterers/NoOptionFiltererTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Configs;
@@ -218,16 +219,22 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"{argValue}");
 
-            (OptionFilterer as ArgFilterer<IEnumerable<string>>)
-                .Filter(parseResult.RootCommandResult.Arguments, testBundles, typeSelection, archSelection)
-                .Should().BeEquivalentTo(expected);
+            (OptionFilterer as ArgFilterer<IEnumerable<string>>).Filter(
+                parseResult.RootCommandResult.Tokens.Select(t => t.Value),
+                testBundles,
+                typeSelection,
+                archSelection)
+            .Should().BeEquivalentTo(expected);
         }
 
         internal override void TestFiltererException<TException>(IEnumerable<Bundle> testBundles, string argValue, BundleType typeSelection, BundleArch archSelection)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"{argValue}");
-            Action action = () => (OptionFilterer as ArgFilterer<IEnumerable<string>>)
-                .Filter(parseResult.RootCommandResult.Arguments, testBundles, typeSelection, archSelection);
+            Action action = () => (OptionFilterer as ArgFilterer<IEnumerable<string>>).Filter(
+                parseResult.RootCommandResult.Tokens.Select(t => t.Value),
+                testBundles,
+                typeSelection,
+                archSelection);
 
             action.Should().Throw<TException>();
         }
@@ -235,8 +242,11 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         internal override void TestFiltererException<TException>(IEnumerable<Bundle> testBundles, string argValue, BundleType typeSelection, BundleArch archSelection, string errorMessage)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"{argValue}");
-            Action action = () => (OptionFilterer as ArgFilterer<IEnumerable<string>>)
-                .Filter(parseResult.RootCommandResult.Arguments, testBundles, typeSelection, archSelection);
+            Action action = () => (OptionFilterer as ArgFilterer<IEnumerable<string>>).Filter(
+                parseResult.RootCommandResult.Tokens.Select(t => t.Value),
+                testBundles,
+                typeSelection,
+                archSelection);
 
             action.Should().Throw<TException>(errorMessage);
         }


### PR DESCRIPTION
_Issues:_
1. line breaks in the `list` output (via `GridView`) are still not handled correctly after the upgrade.
![image](https://user-images.githubusercontent.com/20103263/61270297-19991680-a756-11e9-8172-5121e1af6be5.png)