### PR TITLE
`System.CommandLine` upgrade fixes

### DIFF
--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -412,7 +412,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The specified versions to uninstall..
+        ///   Looks up a localized string similar to The specified version to uninstall..
         /// </summary>
         internal static string UninstallNoOptionArgumentDescription {
             get {
@@ -421,7 +421,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to VERSIONS.
+        ///   Looks up a localized string similar to VERSION.
         /// </summary>
         internal static string UninstallNoOptionArgumentName {
             get {

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -61,15 +61,6 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove ASP.NET Core Runtimes only..
-        /// </summary>
-        internal static string AspNetRuntimeOptionDescription {
-            get {
-                return ResourceManager.GetString("AspNetRuntimeOptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to You must specify either --sdk or --runtime..
         /// </summary>
         internal static string BundleTypeMissingExceptionMessage {
@@ -142,20 +133,20 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core Runtime &amp; Hosting Bundles only..
-        /// </summary>
-        internal static string HostingBundleOptionDescription {
-            get {
-                return ResourceManager.GetString("HostingBundleOptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The specified version is not valid: &quot;{0}&quot;..
         /// </summary>
         internal static string InvalidInputVersionExceptionMessageFormat {
             get {
                 return ResourceManager.GetString("InvalidInputVersionExceptionMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List ASP.NET Core Runtimes..
+        /// </summary>
+        internal static string ListAspNetRuntimeOptionDescription {
+            get {
+                return ResourceManager.GetString("ListAspNetRuntimeOptionDescription", resourceCulture);
             }
         }
         
@@ -201,6 +192,51 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string ListCommandSdkHeader {
             get {
                 return ResourceManager.GetString("ListCommandSdkHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List .NET Core Runtime &amp; Hosting Bundles..
+        /// </summary>
+        internal static string ListHostingBundleOptionDescription {
+            get {
+                return ResourceManager.GetString("ListHostingBundleOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List .NET Core Runtimes..
+        /// </summary>
+        internal static string ListRuntimeOptionDescription {
+            get {
+                return ResourceManager.GetString("ListRuntimeOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List .NET Core SDKs..
+        /// </summary>
+        internal static string ListSdkOptionDescription {
+            get {
+                return ResourceManager.GetString("ListSdkOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List x64 .NET Core SDKs or Runtimes..
+        /// </summary>
+        internal static string ListX64OptionDescription {
+            get {
+                return ResourceManager.GetString("ListX64OptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to List x86 .NET Core SDKs or Runtimes..
+        /// </summary>
+        internal static string ListX86OptionDescription {
+            get {
+                return ResourceManager.GetString("ListX86OptionDescription", resourceCulture);
             }
         }
         
@@ -264,24 +300,6 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string RequiredArgMissingForUninstallCommandExceptionMessage {
             get {
                 return ResourceManager.GetString("RequiredArgMissingForUninstallCommandExceptionMessage", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core Runtimes only..
-        /// </summary>
-        internal static string RuntimeOptionDescription {
-            get {
-                return ResourceManager.GetString("RuntimeOptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core SDKs only..
-        /// </summary>
-        internal static string SdkOptionDescription {
-            get {
-                return ResourceManager.GetString("SdkOptionDescription", resourceCulture);
             }
         }
         
@@ -376,6 +394,15 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Remove ASP.NET Core Runtimes only..
+        /// </summary>
+        internal static string UninstallAspNetRuntimeOptionDescription {
+            get {
+                return ResourceManager.GetString("UninstallAspNetRuntimeOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Timeout during uninstall: {0}..
         /// </summary>
         internal static string UninstallationFailedExceptionMessageFormat {
@@ -390,6 +417,15 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string UninstallationFailedExceptionWithExitCodeMessageFormat {
             get {
                 return ResourceManager.GetString("UninstallationFailedExceptionWithExitCodeMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove .NET Core Runtime &amp; Hosting Bundles only..
+        /// </summary>
+        internal static string UninstallHostingBundleOptionDescription {
+            get {
+                return ResourceManager.GetString("UninstallHostingBundleOptionDescription", resourceCulture);
             }
         }
         
@@ -448,20 +484,38 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to LEVEL.
+        ///   Looks up a localized string similar to Remove .NET Core Runtimes only..
         /// </summary>
-        internal static string UninstallVerbosityOptionArgumentName {
+        internal static string UninstallRuntimeOptionDescription {
             get {
-                return ResourceManager.GetString("UninstallVerbosityOptionArgumentName", resourceCulture);
+                return ResourceManager.GetString("UninstallRuntimeOptionDescription", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]..
+        ///   Looks up a localized string similar to Remove .NET Core SDKs only..
         /// </summary>
-        internal static string UninstallVerbosityOptionDescription {
+        internal static string UninstallSdkOptionDescription {
             get {
-                return ResourceManager.GetString("UninstallVerbosityOptionDescription", resourceCulture);
+                return ResourceManager.GetString("UninstallSdkOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Can be used with --sdk, --runtime and --aspnet-runtime to remove x64..
+        /// </summary>
+        internal static string UninstallX64OptionDescription {
+            get {
+                return ResourceManager.GetString("UninstallX64OptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Can be used with --sdk, --runtime and --aspnet-runtime to remove x86..
+        /// </summary>
+        internal static string UninstallX86OptionDescription {
+            get {
+                return ResourceManager.GetString("UninstallX86OptionDescription", resourceCulture);
             }
         }
         
@@ -475,29 +529,29 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to LEVEL.
+        /// </summary>
+        internal static string VerbosityOptionArgumentName {
+            get {
+                return ResourceManager.GetString("VerbosityOptionArgumentName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]..
+        /// </summary>
+        internal static string VerbosityOptionDescription {
+            get {
+                return ResourceManager.GetString("VerbosityOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Do not use a version before an option: {0}..
         /// </summary>
         internal static string VersionBeforeOptionExceptionMessageFormat {
             get {
                 return ResourceManager.GetString("VersionBeforeOptionExceptionMessageFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can be used with --sdk, --runtime and --aspnet-runtime to remove x64..
-        /// </summary>
-        internal static string X64OptionDescription {
-            get {
-                return ResourceManager.GetString("X64OptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Can be used with --sdk, --runtime and --aspnet-runtime to remove x86..
-        /// </summary>
-        internal static string X86OptionDescription {
-            get {
-                return ResourceManager.GetString("X86OptionDescription", resourceCulture);
             }
         }
     }

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -141,10 +141,10 @@
   <data name="RequiredArgMissingForUninstallCommandExceptionMessage" xml:space="preserve">
     <value>Required argument missing for the uninstall command.</value>
   </data>
-  <data name="RuntimeOptionDescription" xml:space="preserve">
+  <data name="UninstallRuntimeOptionDescription" xml:space="preserve">
     <value>Remove .NET Core Runtimes only.</value>
   </data>
-  <data name="SdkOptionDescription" xml:space="preserve">
+  <data name="UninstallSdkOptionDescription" xml:space="preserve">
     <value>Remove .NET Core SDKs only.</value>
   </data>
   <data name="SpecifiedVersionNotFoundExceptionMessageFormat" xml:space="preserve">
@@ -198,16 +198,16 @@
   <data name="UninstallNoOptionDescription" xml:space="preserve">
     <value>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers.</value>
   </data>
-  <data name="UninstallVerbosityOptionArgumentName" xml:space="preserve">
+  <data name="VerbosityOptionArgumentName" xml:space="preserve">
     <value>LEVEL</value>
   </data>
-  <data name="UninstallVerbosityOptionDescription" xml:space="preserve">
+  <data name="VerbosityOptionDescription" xml:space="preserve">
     <value>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</value>
   </data>
-  <data name="X64OptionDescription" xml:space="preserve">
+  <data name="UninstallX64OptionDescription" xml:space="preserve">
     <value>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</value>
   </data>
-  <data name="X86OptionDescription" xml:space="preserve">
+  <data name="UninstallX86OptionDescription" xml:space="preserve">
     <value>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</value>
   </data>
   <data name="NotAdminExceptionMessage" xml:space="preserve">
@@ -249,13 +249,13 @@
   <data name="CancelingMessage" xml:space="preserve">
     <value>Canceling: waiting for the current uninstall to complete.</value>
   </data>
-  <data name="AspNetRuntimeOptionDescription" xml:space="preserve">
+  <data name="UninstallAspNetRuntimeOptionDescription" xml:space="preserve">
     <value>Remove ASP.NET Core Runtimes only.</value>
   </data>
   <data name="ListCommandAspNetRuntimeHeader" xml:space="preserve">
     <value>ASP.NET Core Runtimes:</value>
   </data>
-  <data name="HostingBundleOptionDescription" xml:space="preserve">
+  <data name="UninstallHostingBundleOptionDescription" xml:space="preserve">
     <value>Remove .NET Core Runtime &amp; Hosting Bundles only.</value>
   </data>
   <data name="ListCommandHostingBundleHeader" xml:space="preserve">
@@ -263,5 +263,23 @@
   </data>
   <data name="HostingBundleFootnoteFormat" xml:space="preserve">
     <value>"{0}" is treated as a version {1} in this tool.</value>
+  </data>
+  <data name="ListAspNetRuntimeOptionDescription" xml:space="preserve">
+    <value>List ASP.NET Core Runtimes.</value>
+  </data>
+  <data name="ListHostingBundleOptionDescription" xml:space="preserve">
+    <value>List .NET Core Runtime &amp; Hosting Bundles.</value>
+  </data>
+  <data name="ListRuntimeOptionDescription" xml:space="preserve">
+    <value>List .NET Core Runtimes.</value>
+  </data>
+  <data name="ListSdkOptionDescription" xml:space="preserve">
+    <value>List .NET Core SDKs.</value>
+  </data>
+  <data name="ListX64OptionDescription" xml:space="preserve">
+    <value>List x64 .NET Core SDKs or Runtimes.</value>
+  </data>
+  <data name="ListX86OptionDescription" xml:space="preserve">
+    <value>List x86 .NET Core SDKs or Runtimes.</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -190,10 +190,10 @@
     <value>Remove .NET Core SDKs or Runtimes that match the specified `major.minor` version.</value>
   </data>
   <data name="UninstallNoOptionArgumentDescription" xml:space="preserve">
-    <value>The specified versions to uninstall.</value>
+    <value>The specified version to uninstall.</value>
   </data>
   <data name="UninstallNoOptionArgumentName" xml:space="preserve">
-    <value>VERSIONS</value>
+    <value>VERSION</value>
   </data>
   <data name="UninstallNoOptionDescription" xml:space="preserve">
     <value>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers.</value>

--- a/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
+++ b/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
@@ -46,7 +46,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
                     group.First().Version,
                     BundleArch.X64,
                     CombineUninstallCommands(group.Select(tuple => tuple.UninstallCommand)),
-                    string.Format(bundleTypeString, group.First().Version.ToString())));
+                    string.Format(LocalizableStrings.MacOsBundleDisplayNameFormat, bundleTypeString, group.First().Version.ToString())));
         }
 
         private static IEnumerable<(TBundleVersion Version, string UninstallCommand)> GetInstalledVersionsAndUninstallCommands<TBundleVersion>(string path)

--- a/src/dotnet-core-uninstall/MacOs/SupportedBundleTypeConfigs.cs
+++ b/src/dotnet-core-uninstall/MacOs/SupportedBundleTypeConfigs.cs
@@ -30,8 +30,15 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
         public static readonly IEnumerable<BundleTypePrintInfo> SupportedBundleTypes =
             new BundleTypePrintInfo[]
             {
-                new BundleTypePrintInfo<SdkVersion>(LocalizableStrings.ListCommandSdkHeader, _gridViewGeneratorWithArch, "sdk"),
-                new BundleTypePrintInfo<RuntimeVersion>(LocalizableStrings.ListCommandRuntimeHeader, _gridViewGeneratorWithArch, "runtime")
+                new BundleTypePrintInfo<SdkVersion>(
+                    LocalizableStrings.ListCommandSdkHeader,
+                    _gridViewGeneratorWithArch,
+                    CommandLineConfigs.SdkOptionName),
+
+                new BundleTypePrintInfo<RuntimeVersion>(
+                    LocalizableStrings.ListCommandRuntimeHeader,
+                    _gridViewGeneratorWithArch,
+                    CommandLineConfigs.RuntimeOptionName)
             };
     }
 }

--- a/src/dotnet-core-uninstall/MacOs/SupportedBundleTypeConfigs.cs
+++ b/src/dotnet-core-uninstall/MacOs/SupportedBundleTypeConfigs.cs
@@ -30,8 +30,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
         public static readonly IEnumerable<BundleTypePrintInfo> SupportedBundleTypes =
             new BundleTypePrintInfo[]
             {
-                new BundleTypePrintInfo<SdkVersion>(LocalizableStrings.ListCommandSdkHeader, _gridViewGeneratorWithArch),
-                new BundleTypePrintInfo<RuntimeVersion>(LocalizableStrings.ListCommandRuntimeHeader, _gridViewGeneratorWithArch)
+                new BundleTypePrintInfo<SdkVersion>(LocalizableStrings.ListCommandSdkHeader, _gridViewGeneratorWithArch, "sdk"),
+                new BundleTypePrintInfo<RuntimeVersion>(LocalizableStrings.ListCommandRuntimeHeader, _gridViewGeneratorWithArch, "runtime")
             };
     }
 }

--- a/src/dotnet-core-uninstall/MacOs/SupportedBundleTypeConfigs.cs
+++ b/src/dotnet-core-uninstall/MacOs/SupportedBundleTypeConfigs.cs
@@ -4,11 +4,11 @@ using System.CommandLine.Rendering.Views;
 using System.Linq;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
-using Microsoft.DotNet.Tools.Uninstall.Shared.Commands;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Configs;
 
 namespace Microsoft.DotNet.Tools.Uninstall.MacOs
 {
-    internal static class ListCommandExec
+    internal static class SupportedBundleTypeConfigs
     {
         private static readonly Func<IList<Bundle>, GridView> _gridViewGeneratorWithArch = bundles =>
         {

--- a/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
@@ -21,13 +21,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             {
                 Execute(
                     RegistryQuery.GetInstalledBundles(),
-                    Windows.ListCommandExec.SupportedBundleTypes);
+                    Windows.SupportedBundleTypeConfigs.SupportedBundleTypes);
             }
             else if (RuntimeInfo.RunningOnOSX)
             {
                 Execute(
                     FileSystemExplorer.GetInstalledBundles(),
-                    MacOs.ListCommandExec.SupportedBundleTypes);
+                    MacOs.SupportedBundleTypeConfigs.SupportedBundleTypes);
             }
             else
             {

--- a/src/dotnet-core-uninstall/Shared/Configs/BundleTypePrintInfo.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/BundleTypePrintInfo.cs
@@ -4,7 +4,7 @@ using System.CommandLine.Rendering.Views;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
 
-namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
+namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 {
     internal abstract class BundleTypePrintInfo
     {

--- a/src/dotnet-core-uninstall/Shared/Configs/BundleTypePrintInfo.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/BundleTypePrintInfo.cs
@@ -12,11 +12,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
         public string Header { get; }
         public Func<IList<Bundle>, GridView> GridViewGenerator { get; }
+        public string OptionName { get; }
 
-        protected BundleTypePrintInfo(string header, Func<IList<Bundle>, GridView> gridViewGenerator)
+        protected BundleTypePrintInfo(string header, Func<IList<Bundle>, GridView> gridViewGenerator, string optionName)
         {
             Header = header ?? throw new ArgumentNullException();
             GridViewGenerator = gridViewGenerator ?? throw new ArgumentNullException();
+            OptionName = optionName ?? throw new ArgumentNullException();
         }
 
         public abstract IEnumerable<Bundle> Filter(IEnumerable<Bundle> bundles);
@@ -27,7 +29,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
     {
         public override BundleType Type => new TBundleVersion().Type;
 
-        public BundleTypePrintInfo(string header, Func<IList<Bundle>, GridView> gridViewGenerator) : base(header, gridViewGenerator) { }
+        public BundleTypePrintInfo(string header, Func<IList<Bundle>, GridView> gridViewGenerator, string optionName) :
+            base(header, gridViewGenerator, optionName)
+        { }
 
         public override IEnumerable<Bundle> Filter(IEnumerable<Bundle> bundles)
         {

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -13,6 +13,14 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 {
     internal static class CommandLineConfigs
     {
+        public static readonly string SdkOptionName = "sdk";
+        public static readonly string RuntimeOptionName = "runtime";
+        public static readonly string AspNetRuntimeOptionName = "aspnet-runtime";
+        public static readonly string HostingBundleOptionName = "hosting-bundle";
+        public static readonly string X64OptionName = "x64";
+        public static readonly string X86OptionName = "x86";
+        public static readonly string ListCommandName = "list";
+
         public static readonly Option UninstallAllOption = new Option(
             "--all",
             LocalizableStrings.UninstallAllOptionDescription);
@@ -63,39 +71,63 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             }
         };
 
-        public static readonly Option UninstallVerbosityOption = new Option(
+        public static readonly Option VerbosityOption = new Option(
             new[] { "--verbosity", "-v" },
-            LocalizableStrings.UninstallVerbosityOptionDescription)
+            LocalizableStrings.VerbosityOptionDescription)
         {
             Argument = new Argument<string>
             {
-                Name = LocalizableStrings.UninstallVerbosityOptionArgumentName
+                Name = LocalizableStrings.VerbosityOptionArgumentName
             }
         };
 
-        public static readonly Option SdkOption = new Option(
-            "--sdk",
-            LocalizableStrings.SdkOptionDescription);
+        public static readonly Option UninstallSdkOption = new Option(
+            $"--{SdkOptionName}",
+            LocalizableStrings.UninstallSdkOptionDescription);
 
-        public static readonly Option RuntimeOption = new Option(
-            "--runtime",
-            LocalizableStrings.RuntimeOptionDescription);
+        public static readonly Option UninstallRuntimeOption = new Option(
+            $"--{RuntimeOptionName}",
+            LocalizableStrings.UninstallRuntimeOptionDescription);
 
-        public static readonly Option AspNetRuntimeOption = new Option(
-            "--aspnet-runtime",
-            LocalizableStrings.AspNetRuntimeOptionDescription);
+        public static readonly Option UninstallAspNetRuntimeOption = new Option(
+            $"--{AspNetRuntimeOptionName}",
+            LocalizableStrings.UninstallAspNetRuntimeOptionDescription);
 
-        public static readonly Option HostingBundleOption = new Option(
-            "--hosting-bundle",
-            LocalizableStrings.HostingBundleOptionDescription);
+        public static readonly Option UninstallHostingBundleOption = new Option(
+            $"--{HostingBundleOptionName}",
+            LocalizableStrings.UninstallHostingBundleOptionDescription);
 
-        public static readonly Option X86Option = new Option(
-            "--x86",
-            LocalizableStrings.X86OptionDescription);
+        public static readonly Option ListSdkOption = new Option(
+            $"--{SdkOptionName}",
+            LocalizableStrings.ListSdkOptionDescription);
 
-        public static readonly Option X64Option = new Option(
-            "--x64",
-            LocalizableStrings.X64OptionDescription);
+        public static readonly Option ListRuntimeOption = new Option(
+            $"--{RuntimeOptionName}",
+            LocalizableStrings.ListRuntimeOptionDescription);
+
+        public static readonly Option ListAspNetRuntimeOption = new Option(
+            $"--{AspNetRuntimeOptionName}",
+            LocalizableStrings.ListAspNetRuntimeOptionDescription);
+
+        public static readonly Option ListHostingBundleOption = new Option(
+            $"--{HostingBundleOptionName}",
+            LocalizableStrings.ListHostingBundleOptionDescription);
+
+        public static readonly Option UninstallX64Option = new Option(
+            $"--{X64OptionName}",
+            LocalizableStrings.UninstallX64OptionDescription);
+
+        public static readonly Option UninstallX86Option = new Option(
+            $"--{X86OptionName}",
+            LocalizableStrings.UninstallX86OptionDescription);
+
+        public static readonly Option ListX64Option = new Option(
+            $"--{X64OptionName}",
+            LocalizableStrings.ListX64OptionDescription);
+
+        public static readonly Option ListX86Option = new Option(
+            $"--{X86OptionName}",
+            LocalizableStrings.ListX86OptionDescription);
 
         public static readonly Option VersionOption = new Option(
             "--version")
@@ -119,26 +151,11 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             UninstallMajorMinorOption,
         };
 
-        public static readonly IEnumerable<Option> BundleTypeOptions = new Option[]
-        {
-            SdkOption,
-            RuntimeOption,
-            AspNetRuntimeOption,
-            HostingBundleOption
-        };
-
-        public static readonly IEnumerable<Option> AuxOptions = new Option[]
-        {
-            UninstallVerbosityOption,
-            X86Option,
-            X64Option
-        };
-
         public static readonly RootCommand UninstallRootCommand = new RootCommand(
             LocalizableStrings.UninstallNoOptionDescription);
 
         public static readonly Command ListCommand = new Command(
-            "list",
+            ListCommandName,
             LocalizableStrings.ListCommandDescription);
 
         public static readonly Dictionary<string, VerbosityLevel> VerbosityLevels = new Dictionary<string, VerbosityLevel>
@@ -151,8 +168,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
         };
 
         public static readonly ParseResult CommandLineParseResult;
-
-        public static readonly IEnumerable<Option> SupportedBundleTypeOptions;
+        public static readonly IEnumerable<Option> UninstallAuxOptions;
+        public static readonly IEnumerable<Option> ListAuxOptions;
 
         static CommandLineConfigs()
         {
@@ -164,23 +181,46 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
             UninstallRootCommand.AddCommand(ListCommand);
 
-            var supportedBundleTypes = GetSupportedBundleTypes();
+            var supportedBundleTypeNames = GetSupportedBundleTypes().Select(type => type.OptionName);
 
-            SupportedBundleTypeOptions = BundleTypeOptions
-                .Where(option => supportedBundleTypes.Select(type => type.OptionName).Contains(option.Name));
+            var supportedUninstallBundleTypeOptions = new Option[]
+            {
+                UninstallSdkOption,
+                UninstallRuntimeOption,
+                UninstallAspNetRuntimeOption,
+                UninstallHostingBundleOption
+            }
+            .Where(option => supportedBundleTypeNames.Contains(option.Name));
+
+            var supportedListBundleTypeOptions = new Option[]
+            {
+                ListSdkOption,
+                ListRuntimeOption,
+                ListAspNetRuntimeOption,
+                ListHostingBundleOption
+            }
+            .Where(option => supportedBundleTypeNames.Contains(option.Name));
+
+            UninstallAuxOptions = supportedUninstallBundleTypeOptions
+                .Append(VerbosityOption)
+                .Append(UninstallX64Option)
+                .Append(UninstallX86Option)
+                .Append(VersionOption)
+                .Append(DoItOption);
+
+            ListAuxOptions = supportedListBundleTypeOptions
+                .Append(VerbosityOption)
+                .Append(ListX64Option)
+                .Append(ListX86Option);
 
             foreach (var option in UninstallMainOptions
-                .Concat(SupportedBundleTypeOptions)
-                .Concat(AuxOptions)
-                .Append(VersionOption)
-                .Append(DoItOption)
+                .Concat(UninstallAuxOptions)
                 .OrderBy(option => option.Name))
             {
                 UninstallRootCommand.AddOption(option);
             }
 
-            foreach (var option in AuxOptions
-                .Concat(SupportedBundleTypeOptions)
+            foreach (var option in ListAuxOptions
                 .OrderBy(option => option.Name))
             {
                 ListCommand.AddOption(option);
@@ -241,29 +281,23 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
         public static BundleArch GetArchSelection(this CommandResult commandResult)
         {
-            var archSelection = (BundleArch)0;
-
-            if (commandResult.OptionResult(X86Option.Name) != null)
+            var archSelection = new[]
             {
-                archSelection |= BundleArch.X86;
+                (OptionName: X64OptionName, Arch: BundleArch.X64),
+                (OptionName: X86OptionName, Arch: BundleArch.X86)
             }
+            .Where(tuple => commandResult.OptionResult(tuple.OptionName) != null)
+            .Select(tuple => tuple.Arch)
+            .Aggregate((BundleArch)0, (orSum, next) => orSum | next);
 
-            if (commandResult.OptionResult(X64Option.Name) != null)
-            {
-                archSelection |= BundleArch.X64;
-            }
-
-            if (archSelection == 0)
-            {
-                archSelection = Enum.GetValues(typeof(BundleArch)).OfType<BundleArch>().Aggregate((BundleArch)0, (orSum, next) => orSum | next);
-            }
-
-            return archSelection;
+            return archSelection == 0 ?
+                archSelection = Enum.GetValues(typeof(BundleArch)).OfType<BundleArch>().Aggregate((BundleArch)0, (orSum, next) => orSum | next) :
+                archSelection;
         }
 
         public static VerbosityLevel GetVerbosityLevel(this CommandResult commandResult)
         {
-            var optionResult = commandResult.OptionResult(UninstallVerbosityOption.Name);
+            var optionResult = commandResult.OptionResult(VerbosityOption.Name);
 
             if (optionResult == null)
             {

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -97,7 +97,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             LocalizableStrings.X64OptionDescription);
 
         public static readonly Option VersionOption = new Option(
-            "--version");
+            "--version")
+        {
+            IsHidden = true
+        };
 
         public static readonly Option DoItOption = new Option(
             "--do-it",

--- a/src/dotnet-core-uninstall/Windows/SupportedBundleTypeConfigs.cs
+++ b/src/dotnet-core-uninstall/Windows/SupportedBundleTypeConfigs.cs
@@ -48,10 +48,25 @@ namespace Microsoft.DotNet.Tools.Uninstall.Windows
         public static readonly IEnumerable<BundleTypePrintInfo> SupportedBundleTypes =
             new BundleTypePrintInfo[]
             {
-                new BundleTypePrintInfo<SdkVersion>(LocalizableStrings.ListCommandSdkHeader, _gridViewGeneratorWithArch, "sdk"),
-                new BundleTypePrintInfo<RuntimeVersion>(LocalizableStrings.ListCommandRuntimeHeader, _gridViewGeneratorWithArch, "runtime"),
-                new BundleTypePrintInfo<AspNetRuntimeVersion>(LocalizableStrings.ListCommandAspNetRuntimeHeader, _gridViewGeneratorWithArch, "aspnet-runtime"),
-                new BundleTypePrintInfo<HostingBundleVersion>(LocalizableStrings.ListCommandHostingBundleHeader, _gridViewGeneratorWithoutArch, "hosting-bundle")
+                new BundleTypePrintInfo<SdkVersion>(
+                    LocalizableStrings.ListCommandSdkHeader,
+                    _gridViewGeneratorWithArch,
+                    CommandLineConfigs.SdkOptionName),
+
+                new BundleTypePrintInfo<RuntimeVersion>(
+                    LocalizableStrings.ListCommandRuntimeHeader,
+                    _gridViewGeneratorWithArch,
+                    CommandLineConfigs.RuntimeOptionName),
+
+                new BundleTypePrintInfo<AspNetRuntimeVersion>(
+                    LocalizableStrings.ListCommandAspNetRuntimeHeader,
+                    _gridViewGeneratorWithArch,
+                    CommandLineConfigs.AspNetRuntimeOptionName),
+
+                new BundleTypePrintInfo<HostingBundleVersion>(
+                    LocalizableStrings.ListCommandHostingBundleHeader,
+                    _gridViewGeneratorWithoutArch,
+                    CommandLineConfigs.HostingBundleOptionName)
             };
     }
 }

--- a/src/dotnet-core-uninstall/Windows/SupportedBundleTypeConfigs.cs
+++ b/src/dotnet-core-uninstall/Windows/SupportedBundleTypeConfigs.cs
@@ -4,11 +4,11 @@ using System.CommandLine.Rendering.Views;
 using System.Linq;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
-using Microsoft.DotNet.Tools.Uninstall.Shared.Commands;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Configs;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Windows
 {
-    internal static class ListCommandExec
+    internal static class SupportedBundleTypeConfigs
     {
         private static readonly Func<IList<Bundle>, GridView> _gridViewGeneratorWithArch = bundles =>
         {

--- a/src/dotnet-core-uninstall/Windows/SupportedBundleTypeConfigs.cs
+++ b/src/dotnet-core-uninstall/Windows/SupportedBundleTypeConfigs.cs
@@ -48,10 +48,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Windows
         public static readonly IEnumerable<BundleTypePrintInfo> SupportedBundleTypes =
             new BundleTypePrintInfo[]
             {
-                new BundleTypePrintInfo<SdkVersion>(LocalizableStrings.ListCommandSdkHeader, _gridViewGeneratorWithArch),
-                new BundleTypePrintInfo<RuntimeVersion>(LocalizableStrings.ListCommandRuntimeHeader, _gridViewGeneratorWithArch),
-                new BundleTypePrintInfo<AspNetRuntimeVersion>(LocalizableStrings.ListCommandAspNetRuntimeHeader, _gridViewGeneratorWithArch),
-                new BundleTypePrintInfo<HostingBundleVersion>(LocalizableStrings.ListCommandHostingBundleHeader, _gridViewGeneratorWithoutArch)
+                new BundleTypePrintInfo<SdkVersion>(LocalizableStrings.ListCommandSdkHeader, _gridViewGeneratorWithArch, "sdk"),
+                new BundleTypePrintInfo<RuntimeVersion>(LocalizableStrings.ListCommandRuntimeHeader, _gridViewGeneratorWithArch, "runtime"),
+                new BundleTypePrintInfo<AspNetRuntimeVersion>(LocalizableStrings.ListCommandAspNetRuntimeHeader, _gridViewGeneratorWithArch, "aspnet-runtime"),
+                new BundleTypePrintInfo<HostingBundleVersion>(LocalizableStrings.ListCommandHostingBundleHeader, _gridViewGeneratorWithoutArch, "hosting-bundle")
             };
     }
 }

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="cs" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="de" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="es" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="fr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="it" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ja" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ko" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pl" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="pt-BR" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="ru" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="tr" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hans" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -188,13 +188,13 @@
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified versions to uninstall.</source>
-        <target state="new">The specified versions to uninstall.</target>
+        <source>The specified version to uninstall.</source>
+        <target state="new">The specified version to uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
-        <source>VERSIONS</source>
-        <target state="new">VERSIONS</target>
+        <source>VERSION</source>
+        <target state="new">VERSION</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -2,11 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 xliff-core-1.2-transitional.xsd">
   <file datatype="xml" source-language="en" target-language="zh-Hant" original="../LocalizableStrings.resx">
     <body>
-      <trans-unit id="AspNetRuntimeOptionDescription">
-        <source>Remove ASP.NET Core Runtimes only.</source>
-        <target state="new">Remove ASP.NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="BundleTypeMissingExceptionMessage">
         <source>You must specify either --sdk or --runtime.</source>
         <target state="new">You must specify either --sdk or --runtime.</target>
@@ -47,14 +42,14 @@
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
         <note />
       </trans-unit>
-      <trans-unit id="HostingBundleOptionDescription">
-        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
-        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="InvalidInputVersionExceptionMessageFormat">
         <source>The specified version is not valid: "{0}".</source>
         <target state="new">The specified version is not valid: "{0}".</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListAspNetRuntimeOptionDescription">
+        <source>List ASP.NET Core Runtimes.</source>
+        <target state="new">List ASP.NET Core Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandAspNetRuntimeHeader">
@@ -80,6 +75,31 @@
       <trans-unit id="ListCommandSdkHeader">
         <source>.NET Core SDKs:</source>
         <target state="new">.NET Core SDKs:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListHostingBundleOptionDescription">
+        <source>List .NET Core Runtime &amp; Hosting Bundles.</source>
+        <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListRuntimeOptionDescription">
+        <source>List .NET Core Runtimes.</source>
+        <target state="new">List .NET Core Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListSdkOptionDescription">
+        <source>List .NET Core SDKs.</source>
+        <target state="new">List .NET Core SDKs.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX64OptionDescription">
+        <source>List x64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListX86OptionDescription">
+        <source>List x86 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -115,16 +135,6 @@
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">
         <source>Required argument missing for the uninstall command.</source>
         <target state="new">Required argument missing for the uninstall command.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RuntimeOptionDescription">
-        <source>Remove .NET Core Runtimes only.</source>
-        <target state="new">Remove .NET Core Runtimes only.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="SdkOptionDescription">
-        <source>Remove .NET Core SDKs only.</source>
-        <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -177,6 +187,16 @@
         <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallAspNetRuntimeOptionDescription">
+        <source>Remove ASP.NET Core Runtimes only.</source>
+        <target state="new">Remove ASP.NET Core Runtimes only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallHostingBundleOptionDescription">
+        <source>Remove .NET Core Runtime &amp; Hosting Bundles only.</source>
+        <target state="new">Remove .NET Core Runtime &amp; Hosting Bundles only.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallMajorMinorOptionArgumentName">
         <source>MAJOR_MINOR</source>
         <target state="new">MAJOR_MINOR</target>
@@ -207,14 +227,24 @@
         <target state="new">Uninstalling: {0}.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionArgumentName">
-        <source>LEVEL</source>
-        <target state="new">LEVEL</target>
+      <trans-unit id="UninstallRuntimeOptionDescription">
+        <source>Remove .NET Core Runtimes only.</source>
+        <target state="new">Remove .NET Core Runtimes only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallVerbosityOptionDescription">
-        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
-        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+      <trans-unit id="UninstallSdkOptionDescription">
+        <source>Remove .NET Core SDKs only.</source>
+        <target state="new">Remove .NET Core SDKs only.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallX86OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallationFailedExceptionMessageFormat">
@@ -232,19 +262,19 @@
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
         <note />
       </trans-unit>
+      <trans-unit id="VerbosityOptionArgumentName">
+        <source>LEVEL</source>
+        <target state="new">LEVEL</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VerbosityOptionDescription">
+        <source>Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
+        <target state="new">Set the verbosity level. Allowed values are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X64OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="X86OptionDescription">
-        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</source>
-        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</target>
         <note />
       </trans-unit>
     </body>

--- a/test/dotnet-core-uninstall.Tests/Attributes/MacOsOnlyTheory.cs
+++ b/test/dotnet-core-uninstall.Tests/Attributes/MacOsOnlyTheory.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Uninstall.Tests.Attributes
+{
+    internal sealed class MacOsOnlyTheory : TheoryAttribute
+    {
+        public MacOsOnlyTheory()
+        {
+            if (!RuntimeInfo.RunningOnOSX)
+            {
+                Skip = "Ignored on non-macOS platforms";
+            }
+        }
+    }
+}

--- a/test/dotnet-core-uninstall.Tests/Attributes/WindowsOnlyTheory.cs
+++ b/test/dotnet-core-uninstall.Tests/Attributes/WindowsOnlyTheory.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Uninstall.Tests.Attributes
+{
+    internal sealed class WindowsOnlyTheory : TheoryAttribute
+    {
+        public WindowsOnlyTheory()
+        {
+            if (!RuntimeInfo.RunningOnWindows)
+            {
+                Skip = "Ignored on non-Windows platforms";
+            }
+        }
+    }
+}

--- a/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
@@ -39,8 +39,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnparsedTokens.Should().BeEmpty();
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
-            CommandLineConfigs.AuxOptions
-                .Concat(CommandLineConfigs.SupportedBundleTypeOptions)
+            CommandLineConfigs.ListAuxOptions
                 .Select(option => option.Name)
                 .Where(option => parseResult.CommandResult.OptionResult(option) != null)
                 .Should().BeEquivalentTo(expectedAuxOptions);
@@ -67,8 +66,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnparsedTokens.Should().BeEmpty();
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
-            CommandLineConfigs.AuxOptions
-                .Concat(CommandLineConfigs.SupportedBundleTypeOptions)
+            CommandLineConfigs.ListAuxOptions
                 .Select(option => option.Name)
                 .Where(option => parseResult.CommandResult.OptionResult(option) != null)
                 .Should().BeEquivalentTo(expectedAuxOptions);
@@ -157,8 +155,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnparsedTokens.Should().BeEmpty();
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
-            CommandLineConfigs.AuxOptions
-                .Concat(CommandLineConfigs.SupportedBundleTypeOptions)
+            CommandLineConfigs.UninstallAuxOptions
                 .Select(option => option.Name)
                 .Where(option => parseResult.CommandResult.OptionResult(option) != null)
                 .Should().BeEquivalentTo(expectedAuxOptions);
@@ -180,8 +177,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnparsedTokens.Should().BeEmpty();
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
-            CommandLineConfigs.AuxOptions
-                .Concat(CommandLineConfigs.SupportedBundleTypeOptions)
+            CommandLineConfigs.UninstallAuxOptions
                 .Select(option => option.Name)
                 .Where(option => parseResult.CommandResult.OptionResult(option) != null)
                 .Should().BeEquivalentTo(expectedAuxOptions);

--- a/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
@@ -14,7 +14,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
 {
     public class CommandLineConfigsTests
     {
-        [WindowsOnlyTheory]
+        [Theory]
         [InlineData("list", new string[] { })]
         [InlineData("list --sdk", new string[] { "sdk" })]
         [InlineData("list --runtime", new string[] { "runtime" })]
@@ -24,11 +24,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("list --sdk -v q", new string[] { "verbosity", "sdk" })]
         [InlineData("list --runtime --verbosity minimal", new string[] { "verbosity", "runtime" })]
         [InlineData("list --sdk --runtime -v normal", new string[] { "verbosity", "sdk", "runtime" })]
-        [InlineData("list --aspnet-runtime", new string[] { "aspnet-runtime" })]
-        [InlineData("list -v n --aspnet-runtime", new string[] { "verbosity", "aspnet-runtime" })]
-        [InlineData("list --sdk --verbosity diag --aspnet-runtime", new string[] { "verbosity", "sdk", "aspnet-runtime" })]
-        [InlineData("list --runtime --hosting-bundle", new string[] { "runtime", "hosting-bundle" })]
-        internal void TestListCommandAcceptWindows(string command, string[] expectedAuxOptions)
+        internal void TestListCommandAccept(string command, string[] expectedAuxOptions)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
 
@@ -45,17 +41,12 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
                 .Should().BeEquivalentTo(expectedAuxOptions);
         }
 
-        [MacOsOnlyTheory]
-        [InlineData("list", new string[] { })]
-        [InlineData("list --sdk", new string[] { "sdk" })]
-        [InlineData("list --runtime", new string[] { "runtime" })]
-        [InlineData("list --sdk --runtime", new string[] { "sdk", "runtime" })]
-        [InlineData("list -v d", new string[] { "verbosity" })]
-        [InlineData("list --verbosity diag", new string[] { "verbosity" })]
-        [InlineData("list --sdk -v q", new string[] { "verbosity", "sdk" })]
-        [InlineData("list --runtime --verbosity minimal", new string[] { "verbosity", "runtime" })]
-        [InlineData("list --sdk --runtime -v normal", new string[] { "verbosity", "sdk", "runtime" })]
-        internal void TestListCommandAcceptMacOs(string command, string[] expectedAuxOptions)
+        [WindowsOnlyTheory]
+        [InlineData("list --aspnet-runtime", new string[] { "aspnet-runtime" })]
+        [InlineData("list -v n --aspnet-runtime", new string[] { "verbosity", "aspnet-runtime" })]
+        [InlineData("list --sdk --verbosity diag --aspnet-runtime", new string[] { "verbosity", "sdk", "aspnet-runtime" })]
+        [InlineData("list --runtime --hosting-bundle", new string[] { "runtime", "hosting-bundle" })]
+        internal void TestListCommandAcceptWindows(string command, string[] expectedAuxOptions)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
 
@@ -137,7 +128,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnmatchedTokens.Should().BeEmpty();
         }
 
-        [WindowsOnlyTheory]
+        [Theory]
         [InlineData("--all --sdk", new string[] { "sdk" })]
         [InlineData("--all-below 2.2.300 --runtime", new string[] { "runtime" })]
         [InlineData("--all-but 2.1.5 2.1.7 3.0.0-preview-10086 --sdk --runtime", new string[] { "sdk", "runtime" })]
@@ -145,9 +136,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("--all -v quiet --sdk", new string[] { "verbosity", "sdk" })]
         [InlineData("--major-minor 2.3 --verbosity m --runtime", new string[] { "verbosity", "runtime" })]
         [InlineData("--all-but 2.1.5 2.1.7 3.0.0-preview-10086 --sdk -v n --runtime", new string[] { "verbosity", "sdk", "runtime" })]
-        [InlineData("--all --sdk --aspnet-runtime", new string[] { "sdk", "aspnet-runtime" })]
-        [InlineData("--major-minor 1.1 --hosting-bundle -v q", new string[] { "hosting-bundle", "verbosity" })]
-        internal void TestOptionsAcceptAuxWindows(string command, string[] expectedAuxOptions)
+        internal void TestOptionsAcceptAux(string command, string[] expectedAuxOptions)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
 
@@ -161,15 +150,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
                 .Should().BeEquivalentTo(expectedAuxOptions);
         }
 
-        [MacOsOnlyTheory]
-        [InlineData("--all --sdk", new string[] { "sdk" })]
-        [InlineData("--all-below 2.2.300 --runtime", new string[] { "runtime" })]
-        [InlineData("--all-but 2.1.5 2.1.7 3.0.0-preview-10086 --sdk --runtime", new string[] { "sdk", "runtime" })]
-        [InlineData("2.1.300 3.0.100-preview-276262-01 --verbosity diagnostic", new string[] { "verbosity" })]
-        [InlineData("--all -v quiet --sdk", new string[] { "verbosity", "sdk" })]
-        [InlineData("--major-minor 2.3 --verbosity m --runtime", new string[] { "verbosity", "runtime" })]
-        [InlineData("--all-but 2.1.5 2.1.7 3.0.0-preview-10086 --sdk -v n --runtime", new string[] { "verbosity", "sdk", "runtime" })]
-        internal void TestOptionsAcceptAuxMacOs(string command, string[] expectedAuxOptions)
+        [WindowsOnlyTheory]
+        [InlineData("--all --sdk --aspnet-runtime", new string[] { "sdk", "aspnet-runtime" })]
+        [InlineData("--major-minor 1.1 --hosting-bundle -v q", new string[] { "hosting-bundle", "verbosity" })]
+        internal void TestOptionsAcceptAuxWindows(string command, string[] expectedAuxOptions)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
 
@@ -197,6 +181,17 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("--major-minor 3.0 --verbosity")]
         [InlineData("--all-but 2.1.5 2.1.7 3.0.0 --sdk --verbosity")]
         internal void TestOptionsReject(string command)
+        {
+            CommandLineConfigs.UninstallRootCommand.Parse(command).Errors
+                .Should().NotBeEmpty();
+        }
+
+        [MacOsOnlyTheory]
+        [InlineData("--all --aspnet-runtime")]
+        [InlineData("--major-minor 1.1 --hosting-bundle")]
+        [InlineData("--all-but 2.2.300 --sdk --aspnet-runtime -v q")]
+        [InlineData("--all-below 2.2 --verbosity normal --sdk --hosting-bundle")]
+        internal void TestOptionsRejectMacOs(string command)
         {
             CommandLineConfigs.UninstallRootCommand.Parse(command).Errors
                 .Should().NotBeEmpty();
@@ -416,19 +411,32 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             action.Should().Throw<VersionBeforeOptionException>(string.Format(LocalizableStrings.VersionBeforeOptionExceptionMessageFormat, option));
         }
 
-        [WindowsOnlyTheory]
-        [InlineData("", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
+        [Theory]
         [InlineData("--sdk", BundleType.Sdk)]
         [InlineData("--runtime", BundleType.Runtime)]
         [InlineData("--sdk --runtime", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("-v q", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
         [InlineData("--sdk --verbosity minimal", BundleType.Sdk)]
         [InlineData("-v normal --runtime", BundleType.Runtime)]
         [InlineData("--sdk --verbosity diag --runtime", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("--all", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
         [InlineData("--sdk --all-but 2.2.300 2.1.700", BundleType.Sdk)]
         [InlineData("--runtime --all-below 3.0.1-preview-10086", BundleType.Runtime)]
         [InlineData("--sdk --runtime --all-previews", BundleType.Sdk | BundleType.Runtime)]
+        internal void TestGetTypeSelectionRootCommand(string command, BundleType expected)
+        {
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.UnparsedTokens.Should().BeEmpty();
+            parseResult.UnmatchedTokens.Should().BeEmpty();
+
+            parseResult.RootCommandResult.GetTypeSelection()
+                .Should().Be(expected);
+        }
+
+        [WindowsOnlyTheory]
+        [InlineData("", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
+        [InlineData("-v q", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
+        [InlineData("--all", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
         [InlineData("--aspnet-runtime", BundleType.AspNetRuntime)]
         [InlineData("--sdk --aspnet-runtime --all-but 2.2.3", BundleType.Sdk | BundleType.AspNetRuntime)]
         [InlineData("--sdk --runtime --aspnet-runtime", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime)]
@@ -448,17 +456,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
 
         [MacOsOnlyTheory]
         [InlineData("", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("--sdk", BundleType.Sdk)]
-        [InlineData("--runtime", BundleType.Runtime)]
-        [InlineData("--sdk --runtime", BundleType.Sdk | BundleType.Runtime)]
         [InlineData("-v q", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("--sdk --verbosity minimal", BundleType.Sdk)]
-        [InlineData("-v normal --runtime", BundleType.Runtime)]
-        [InlineData("--sdk --verbosity diag --runtime", BundleType.Sdk | BundleType.Runtime)]
         [InlineData("--all", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("--sdk --all-but 2.2.300 2.1.700", BundleType.Sdk)]
-        [InlineData("--runtime --all-below 3.0.1-preview-10086", BundleType.Runtime)]
-        [InlineData("--sdk --runtime --all-previews", BundleType.Sdk | BundleType.Runtime)]
         internal void TestGetTypeSelectionRootCommandMacOs(string command, BundleType expected)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);

--- a/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
             CommandLineConfigs.AuxOptions
+                .Concat(CommandLineConfigs.SupportedBundleTypeOptions)
                 .Select(option => option.Name)
                 .Where(option => parseResult.CommandResult.OptionResult(option) != null)
                 .Should().BeEquivalentTo(expectedAuxOptions);
@@ -128,6 +129,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
             CommandLineConfigs.AuxOptions
+                .Concat(CommandLineConfigs.SupportedBundleTypeOptions)
                 .Select(option => option.Name)
                 .Where(option => parseResult.CommandResult.OptionResult(option) != null)
                 .Should().BeEquivalentTo(expectedAuxOptions);

--- a/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
@@ -182,8 +182,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("--all-but 2.1.5 2.1.7 3.0.0 --sdk --verbosity")]
         internal void TestOptionsReject(string command)
         {
-            CommandLineConfigs.UninstallRootCommand.Parse(command).Errors
-                .Should().NotBeEmpty();
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
+
+            (parseResult.Errors.Count != 0 ||
+                parseResult.UnparsedTokens.Count != 0 ||
+                parseResult.UnmatchedTokens.Count != 0 ||
+                parseResult.RootCommandResult.Tokens.Count != 0)
+            .Should().BeTrue();
         }
 
         [MacOsOnlyTheory]
@@ -193,8 +198,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("--all-below 2.2 --verbosity normal --sdk --hosting-bundle")]
         internal void TestOptionsRejectMacOs(string command)
         {
-            CommandLineConfigs.UninstallRootCommand.Parse(command).Errors
-                .Should().NotBeEmpty();
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
+
+            (parseResult.Errors.Count != 0 ||
+                parseResult.UnparsedTokens.Count != 0 ||
+                parseResult.UnmatchedTokens.Count != 0 ||
+                parseResult.RootCommandResult.Tokens.Count != 0)
+            .Should().BeTrue();
         }
 
         [Theory]


### PR DESCRIPTION
1. Updated `VERSION` parameter name of root command. However, the parameter `VERSIONS` of `--all-but` does not change.

    Before upgrade:
    ```
    dotnet-core-uninstall [options] <VERSIONS> [command]
    ```
    After:
    ```
    dotnet-core-uninstall [options] [<VERSION>...] [command]
    ```
2. Hid the `--version` option (the 0.3.0 version of `System.CommandLine` removes `isHidden` from the constructor parameters).
3. Moved `BundleTypePrintInfo` from `Shared.Commands` to `Shared.Configs`. Renamed `Windows.ListCommandExec` and `MacOs.ListCommandExec` to `SupportedBundleTypeConfigs`.
4. Removed `--aspnet-runtime` and `--hosting-bundle` from the macOS version.
5. Added separate option descriptions for the `list` command to align with #54.