### PR TITLE
Bugfix for macOS: path not found on the disk

### DIFF
--- a/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
+++ b/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
@@ -52,15 +52,17 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
         private static IEnumerable<(TBundleVersion Version, string Path)> GetInstalledVersionsAndUninstallCommands<TBundleVersion>(string path)
             where TBundleVersion : BundleVersion, IComparable<TBundleVersion>, new()
         {
-            return new DirectoryInfo(path)
-                .EnumerateDirectories()
-                .Select(dirInfo =>
-                {
-                    var success = BundleVersion.TryFromInput<TBundleVersion>(dirInfo.Name, out var version);
-                    return (Success: success, Version: version, Path: dirInfo.FullName);
-                })
-                .Where(tuple => tuple.Success)
-                .Select(tuple => (tuple.Version, tuple.Path));
+            return Directory.Exists(path) ?
+                new DirectoryInfo(path)
+                    .EnumerateDirectories()
+                    .Select(dirInfo =>
+                    {
+                        var success = BundleVersion.TryFromInput<TBundleVersion>(dirInfo.Name, out var version);
+                        return (Success: success, Version: version, Path: dirInfo.FullName);
+                    })
+                    .Where(tuple => tuple.Success)
+                    .Select(tuple => (tuple.Version, tuple.Path)) :
+                new List<(TBundleVersion Version, string Path)>();
         }
 
         private static string GetUninstallCommand(IEnumerable<string> paths)


### PR DESCRIPTION
The bug can be reproduced if one of `/usr/local/share/dotnet/sdk`, `/usr/local/share/dotnet/shared/Microsoft.AspNetCore.All`, `/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App`, `/usr/local/share/dotnet/shared/Microsoft.NETCore.App` and `/usr/local/share/dotnet/host/fxr` does not exist.

```
$ ./dotnet-core-uninstall list
Unhandled exception: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.IO.DirectoryNotFoundException: Could not find a part of the path '/usr/local/share/dotnet/shared/Microsoft.AspNetCore.All'.
   at System.IO.Enumeration.FileSystemEnumerator`1.CreateDirectoryHandle(String path, Boolean ignoreNotFound)
   at System.IO.Enumeration.FileSystemEnumerator`1.Init()
   at System.IO.Enumeration.FileSystemEnumerator`1..ctor(String directory, Boolean isNormalized, EnumerationOptions options)
   at System.IO.Enumeration.FileSystemEnumerable`1..ctor(String directory, FindTransform transform, EnumerationOptions options, Boolean isNormalized)
   at System.IO.Enumeration.FileSystemEnumerableFactory.DirectoryInfos(String directory, String expression, EnumerationOptions options, Boolean isNormalized)
   at System.IO.DirectoryInfo.InternalEnumerateInfos(String path, String searchPattern, SearchTarget searchTarget, EnumerationOptions options)
   at System.IO.DirectoryInfo.EnumerateDirectories()
   at Microsoft.DotNet.Tools.Uninstall.MacOs.FileSystemExplorer.GetInstalledVersionsAndUninstallCommands[TBundleVersion](String path) in /_/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs:line 55
   at Microsoft.DotNet.Tools.Uninstall.MacOs.FileSystemExplorer.<>c__7`1.<GetInstalledBundles>b__7_0(String path) in /_/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs:line 43
   at System.Linq.Enumerable.SelectManySingleSelectorIterator`2.MoveNext()
   at System.Linq.Lookup`2.Create(IEnumerable`1 source, Func`2 keySelector, IEqualityComparer`1 comparer)
   at System.Linq.GroupedEnumerable`2.GetEnumerator()
   at System.Linq.Enumerable.SelectEnumerableIterator`2.MoveNext()
   at System.Linq.Enumerable.ConcatIterator`1.MoveNext()
   at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
   at System.Collections.Generic.EnumerableHelpers.ToArray[T](IEnumerable`1 source, Int32& length)
   at System.Linq.Buffer`1..ctor(IEnumerable`1 source)
   at System.Linq.OrderedEnumerable`1.ToArray()
   at System.Linq.Enumerable.ToArray[TSource](IEnumerable`1 source)
   at Microsoft.DotNet.Tools.Uninstall.Shared.Commands.ListCommandExec.Execute(IEnumerable`1 bundles, IEnumerable`1 supportedBundleTypes) in /_/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs:line 61
   at Microsoft.DotNet.Tools.Uninstall.Shared.Commands.ListCommandExec.Execute() in /_/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs:line 34
   at Microsoft.DotNet.Tools.Uninstall.Shared.Configs.CommandLineConfigs.<>c.<.cctor>b__37_3() in /_/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs:line 229
   at Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions.ExceptionHandler.<>c__DisplayClass0_0.<HandleException>b__0() in /_/src/dotnet-core-uninstall/Shared/Exceptions/ExceptionHandler.cs:line 13
   --- End of inner exception stack trace ---
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Object[] arguments, Signature sig, Boolean constructor, Boolean wrapExceptions)
   at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at System.Delegate.DynamicInvoke(Object[] args)
   at System.CommandLine.Invocation.ModelBindingCommandHandler.InvokeAsync(InvocationContext context)
   at System.CommandLine.Invocation.InvocationPipeline.<>c__DisplayClass2_0.<<InvokeAsync>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c.<<UseParseErrorReporting>b__16_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c__DisplayClass8_0.<<UseTypoCorrections>b__0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c.<<UseSuggestDirective>b__7_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c.<<UseParseDirective>b__6_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c.<<UseHelp>b__14_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c.<<RegisterWithDotnetSuggest>b__17_0>d.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.CommandLine.Invocation.InvocationExtensions.<>c__DisplayClass5_0.<<UseExceptionHandler>b__0>d.MoveNext()
```