### PR TITLE
Admin privilege check before asking for confirmation

### DIFF
--- a/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
@@ -56,10 +56,20 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             }
             else if (CommandLineConfigs.CommandLineParseResult.RootCommandResult.OptionResult(CommandLineConfigs.YesOption.Name) != null)
             {
+                if (!IsAdmin())
+                {
+                    throw new NotAdminException();
+                }
+
                 DoIt(filtered);
             }
             else
             {
+                if (!IsAdmin())
+                {
+                    throw new NotAdminException();
+                }
+
                 AskIt(filtered);
             }
         }
@@ -112,11 +122,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
 
         private static void DoIt(IEnumerable<Bundle> bundles)
         {
-            if (!IsAdmin())
-            {
-                throw new NotAdminException();
-            }
-
             var verbosityLevel = CommandLineConfigs.CommandLineParseResult.RootCommandResult.GetVerbosityLevel();
             var verbosityLogger = new VerbosityLogger(verbosityLevel);
 


### PR DESCRIPTION
Just realized that currently admin privilege check is after the Y/n confirmation prompt, which is a bit bothering for me. Hence I moved the check before the Y/n prompt.

cc @KathleenDollard 

Before:
```
➜  publish git:(master) ./dotnet-core-uninstall --sdk @version.rsp
The following items will be removed:
  Microsoft .NET Core SDK 2.1.700 (x64)
  Microsoft .NET Core SDK 2.2.300 (x64)

To avoid breaking Visual Studio or other problems, read aka.ms/dotnet-core-uninstall.

Do you want to continue? [Y/n] y
The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.
```

After:
```
➜  dotnet-core-uninstall git:(master) ✗ ../../artifacts/bin/dotnet-core-uninstall/Release/netcoreapp3.0/osx-x64/publish/dotnet-core-uninstall --sdk @/Users/yup/version.rsp
The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.
```