### PR TITLE
Interpreter of MSBuild binlog query language

### DIFF
--- a/src/MSBuildBinLogQuery/Ast/AstNode.cs
+++ b/src/MSBuildBinLogQuery/Ast/AstNode.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.Build.Logging.Query.Result;
 
 namespace Microsoft.Build.Logging.Query.Ast
 {
@@ -23,5 +25,7 @@ namespace Microsoft.Build.Logging.Query.Ast
         {
             return 1;
         }
+
+        public abstract IEnumerable<QueryResult> Interpret(IEnumerable<Component.Component> components);
     }
 }

--- a/src/MSBuildBinLogQuery/Ast/ErrorNode.cs
+++ b/src/MSBuildBinLogQuery/Ast/ErrorNode.cs
@@ -29,16 +29,12 @@ namespace Microsoft.Build.Logging.Query.Ast
 
         public override IEnumerable<QueryResult> Interpret(IEnumerable<Component.Component> components)
         {
-            if (Type == LogNodeType.All)
+            return Type switch
             {
-                return components.SelectMany(component => component.AllErrors);
-            }
-            else if (Type == LogNodeType.Direct)
-            {
-                return components.SelectMany(Component => Component.Errors);
-            }
-
-            throw new ArgumentOutOfRangeException();
+                LogNodeType.All => components.SelectMany(component => component.AllErrors),
+                LogNodeType.Direct => components.SelectMany(Component => Component.Errors),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
         }
     }
 }

--- a/src/MSBuildBinLogQuery/Ast/ErrorNode.cs
+++ b/src/MSBuildBinLogQuery/Ast/ErrorNode.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Build.Logging.Query.Result;
 
 namespace Microsoft.Build.Logging.Query.Ast
 {
@@ -22,6 +25,20 @@ namespace Microsoft.Build.Logging.Query.Ast
         public override int GetHashCode()
         {
             return base.GetHashCode();
+        }
+
+        public override IEnumerable<QueryResult> Interpret(IEnumerable<Component.Component> components)
+        {
+            if (Type == LogNodeType.All)
+            {
+                return components.SelectMany(component => component.AllErrors);
+            }
+            else if (Type == LogNodeType.Direct)
+            {
+                return components.SelectMany(Component => Component.Errors);
+            }
+
+            throw new ArgumentOutOfRangeException();
         }
     }
 }

--- a/src/MSBuildBinLogQuery/Ast/MessageNode.cs
+++ b/src/MSBuildBinLogQuery/Ast/MessageNode.cs
@@ -29,16 +29,12 @@ namespace Microsoft.Build.Logging.Query.Ast
 
         public override IEnumerable<QueryResult> Interpret(IEnumerable<Component.Component> components)
         {
-            if (Type == LogNodeType.All)
+            return Type switch
             {
-                return components.SelectMany(component => component.AllMessages);
-            }
-            else if (Type == LogNodeType.Direct)
-            {
-                return components.SelectMany(Component => Component.Messages);
-            }
-
-            throw new ArgumentOutOfRangeException();
+                LogNodeType.All => components.SelectMany(component => component.AllMessages),
+                LogNodeType.Direct => components.SelectMany(Component => Component.Messages),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
         }
     }
 }

--- a/src/MSBuildBinLogQuery/Ast/MessageNode.cs
+++ b/src/MSBuildBinLogQuery/Ast/MessageNode.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Build.Logging.Query.Result;
 
 namespace Microsoft.Build.Logging.Query.Ast
 {
@@ -22,6 +25,20 @@ namespace Microsoft.Build.Logging.Query.Ast
         public override int GetHashCode()
         {
             return base.GetHashCode();
+        }
+
+        public override IEnumerable<QueryResult> Interpret(IEnumerable<Component.Component> components)
+        {
+            if (Type == LogNodeType.All)
+            {
+                return components.SelectMany(component => component.AllMessages);
+            }
+            else if (Type == LogNodeType.Direct)
+            {
+                return components.SelectMany(Component => Component.Messages);
+            }
+
+            throw new ArgumentOutOfRangeException();
         }
     }
 }

--- a/src/MSBuildBinLogQuery/Ast/ProjectNode.cs
+++ b/src/MSBuildBinLogQuery/Ast/ProjectNode.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Build.Logging.Query.Component;
+using Microsoft.Build.Logging.Query.Result;
 
 namespace Microsoft.Build.Logging.Query.Ast
 {
@@ -26,6 +30,17 @@ namespace Microsoft.Build.Logging.Query.Ast
         public override int GetHashCode()
         {
             return base.GetHashCode();
+        }
+
+        public override IEnumerable<QueryResult> Interpret(IEnumerable<Component.Component> components)
+        {
+            var projects = Filter(components.Select(component => (Component.Build)component));
+            return Next?.Interpret(projects) ?? projects;
+        }
+
+        private IEnumerable<Project> Filter(IEnumerable<Component.Build> builds)
+        {
+            return builds.SelectMany(build => build.ProjectsById.Values);
         }
     }
 }

--- a/src/MSBuildBinLogQuery/Ast/TargetNode.cs
+++ b/src/MSBuildBinLogQuery/Ast/TargetNode.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Build.Logging.Query.Component;
+using Microsoft.Build.Logging.Query.Result;
 
 namespace Microsoft.Build.Logging.Query.Ast
 {
@@ -22,6 +26,17 @@ namespace Microsoft.Build.Logging.Query.Ast
         public override int GetHashCode()
         {
             return base.GetHashCode();
+        }
+
+        public override IEnumerable<QueryResult> Interpret(IEnumerable<Component.Component> components)
+        {
+            var targets = Filter(components.Select(component => (Project)component));
+            return Next?.Interpret(targets) ?? targets;
+        }
+
+        private IEnumerable<Target> Filter(IEnumerable<Project> projects)
+        {
+            return projects.SelectMany(project => project.OrderedTargets);
         }
     }
 }

--- a/src/MSBuildBinLogQuery/Ast/TaskNode.cs
+++ b/src/MSBuildBinLogQuery/Ast/TaskNode.cs
@@ -1,5 +1,9 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Build.Logging.Query.Component;
+using Microsoft.Build.Logging.Query.Result;
 
 namespace Microsoft.Build.Logging.Query.Ast
 {
@@ -22,6 +26,17 @@ namespace Microsoft.Build.Logging.Query.Ast
         public override int GetHashCode()
         {
             return base.GetHashCode();
+        }
+
+        public override IEnumerable<QueryResult> Interpret(IEnumerable<Component.Component> components)
+        {
+            var tasks = Filter(components.Select(component => (Target)component));
+            return Next?.Interpret(tasks) ?? tasks;
+        }
+
+        private IEnumerable<Task> Filter(IEnumerable<Target> targets)
+        {
+            return targets.SelectMany(target => target.OrderedTasks);
         }
     }
 }

--- a/src/MSBuildBinLogQuery/Ast/WarningNode.cs
+++ b/src/MSBuildBinLogQuery/Ast/WarningNode.cs
@@ -1,5 +1,8 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Microsoft.Build.Logging.Query.Result;
 
 namespace Microsoft.Build.Logging.Query.Ast
 {
@@ -22,6 +25,20 @@ namespace Microsoft.Build.Logging.Query.Ast
         public override int GetHashCode()
         {
             return base.GetHashCode();
+        }
+
+        public override IEnumerable<QueryResult> Interpret(IEnumerable<Component.Component> components)
+        {
+            if (Type == LogNodeType.All)
+            {
+                return components.SelectMany(component => component.AllWarnings);
+            }
+            else if (Type == LogNodeType.Direct)
+            {
+                return components.SelectMany(Component => Component.Warnings);
+            }
+
+            throw new ArgumentOutOfRangeException();
         }
     }
 }

--- a/src/MSBuildBinLogQuery/Ast/WarningNode.cs
+++ b/src/MSBuildBinLogQuery/Ast/WarningNode.cs
@@ -29,16 +29,12 @@ namespace Microsoft.Build.Logging.Query.Ast
 
         public override IEnumerable<QueryResult> Interpret(IEnumerable<Component.Component> components)
         {
-            if (Type == LogNodeType.All)
+            return Type switch
             {
-                return components.SelectMany(component => component.AllWarnings);
-            }
-            else if (Type == LogNodeType.Direct)
-            {
-                return components.SelectMany(Component => Component.Warnings);
-            }
-
-            throw new ArgumentOutOfRangeException();
+                LogNodeType.All => components.SelectMany(component => component.AllWarnings),
+                LogNodeType.Direct => components.SelectMany(Component => Component.Warnings),
+                _ => throw new ArgumentOutOfRangeException(),
+            };
         }
     }
 }

--- a/src/MSBuildBinLogQuery/Component/Component.cs
+++ b/src/MSBuildBinLogQuery/Component/Component.cs
@@ -1,10 +1,11 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.Build.Logging.Query.Messaging;
+using Microsoft.Build.Logging.Query.Result;
 
 namespace Microsoft.Build.Logging.Query.Component
 {
-    public abstract class Component
+    public abstract class Component : QueryResult
     {
         public abstract Component Parent { get; }
         public IReadOnlyList<Message> Messages => _messages;

--- a/src/MSBuildBinLogQuery/Messaging/Log.cs
+++ b/src/MSBuildBinLogQuery/Messaging/Log.cs
@@ -1,6 +1,8 @@
+using Microsoft.Build.Logging.Query.Result;
+
 namespace Microsoft.Build.Logging.Query.Messaging
 {
-    public abstract class Log
+    public abstract class Log : QueryResult
     {
         public string Text { get; }
         public Component.Component Parent { get; }

--- a/src/MSBuildBinLogQuery/Result/QueryResult.cs
+++ b/src/MSBuildBinLogQuery/Result/QueryResult.cs
@@ -1,0 +1,6 @@
+namespace Microsoft.Build.Logging.Query.Result
+{
+    public interface QueryResult
+    {
+    }
+}


### PR DESCRIPTION
_Note: This PR should be reviewed after #80 gets merged into `master`._

Practically, the only thing supported now is to distinguish messages/warnings/errors emitted by a project/target/task, respectively.

E.g. `//message` returns all messages that the build generates, while `/message` only returns top-level messages emitted by the build engine itself (such as the summary table) but not by any of the projects.