### PR TITLE
Restructure commands

### DIFF
--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -104,9 +104,9 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         /// <summary>
         ///   Looks up a localized string similar to Display .NET Core SDKs and Runtimes that will be removed..
         /// </summary>
-        internal static string DryRunOptionDescription {
+        internal static string DryRunCommandDescription {
             get {
-                return ResourceManager.GetString("DryRunOptionDescription", resourceCulture);
+                return ResourceManager.GetString("DryRunCommandDescription", resourceCulture);
             }
         }
         
@@ -208,15 +208,6 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Include .NET Core SDKs that cannot be uninstalled..
-        /// </summary>
-        internal static string ListIncludeRequiredOptionDescription {
-            get {
-                return ResourceManager.GetString("ListIncludeRequiredOptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to List .NET Core Runtimes..
         /// </summary>
         internal static string ListRuntimeOptionDescription {
@@ -303,6 +294,15 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string OptionsConflictExceptionMessageFormat {
             get {
                 return ResourceManager.GetString("OptionsConflictExceptionMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove the specified .NET Core SDKs or Runtimes..
+        /// </summary>
+        internal static string RemoveCommandDescription {
+            get {
+                return ResourceManager.GetString("RemoveCommandDescription", resourceCulture);
             }
         }
         

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         ///
         ///To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
         ///
-        ///Run as administrator and use the remove command to remove these items..
+        ///Run as administrator and use the remove command to uninstall these items..
         /// </summary>
         internal static string DryRunOutputFormat {
             get {
@@ -208,7 +208,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to List .NET Core Runtimes..
+        ///   Looks up a localized string similar to List .NET Core Runtimes that can be uninstalled..
         /// </summary>
         internal static string ListRuntimeOptionDescription {
             get {
@@ -217,7 +217,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to List .NET Core SDKs..
+        ///   Looks up a localized string similar to List .NET Core SDKs that can be uninstalled..
         /// </summary>
         internal static string ListSdkOptionDescription {
             get {
@@ -249,6 +249,24 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string MacOsBundleDisplayNameFormat {
             get {
                 return ResourceManager.GetString("MacOsBundleDisplayNameFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required for {0}.{1} Applications, you will not be able to run these applications without this SDK.
+        /// </summary>
+        internal static string MajorMinorRequirementLong {
+            get {
+                return ResourceManager.GetString("MajorMinorRequirementLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required for {0}.{1} Applications.
+        /// </summary>
+        internal static string MajorMinorRequirementShort {
+            get {
+                return ResourceManager.GetString("MajorMinorRequirementShort", resourceCulture);
             }
         }
         
@@ -567,6 +585,24 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio.
+        /// </summary>
+        internal static string UpperLimitRequirementLong {
+            get {
+                return ResourceManager.GetString("UpperLimitRequirementLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot uninstall version {0} and above.
+        /// </summary>
+        internal static string UpperLimitRequirementShort {
+            get {
+                return ResourceManager.GetString("UpperLimitRequirementShort", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic]..
         /// </summary>
         internal static string VerbosityLevelInvalidExceptionMessage {
@@ -599,6 +635,33 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string VersionBeforeOptionExceptionMessageFormat {
             get {
                 return ResourceManager.GetString("VersionBeforeOptionExceptionMessageFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Display .NET Core Uninstall Tool Version Information..
+        /// </summary>
+        internal static string VersionOptionDescription {
+            get {
+                return ResourceManager.GetString("VersionOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required by Visual Studio 2017, Visual Studio will break without this SDK.
+        /// </summary>
+        internal static string VisualStudioRequirementLong {
+            get {
+                return ResourceManager.GetString("VisualStudioRequirementLong", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required by Visual Studio 2017.
+        /// </summary>
+        internal static string VisualStudioRequirementShort {
+            get {
+                return ResourceManager.GetString("VisualStudioRequirementShort", resourceCulture);
             }
         }
         

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -127,6 +127,15 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Execute the command including unreccommended unisntallations..
+        /// </summary>
+        internal static string ForceOptionDescription {
+            get {
+                return ResourceManager.GetString("ForceOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &quot;{0}&quot; is treated as a version {1} in this tool..
         /// </summary>
         internal static string HostingBundleFootnoteFormat {
@@ -253,24 +262,6 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Required for {0}.{1} Applications, you will not be able to run these applications without this SDK.
-        /// </summary>
-        internal static string MajorMinorRequirementLong {
-            get {
-                return ResourceManager.GetString("MajorMinorRequirementLong", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Required for {0}.{1} Applications.
-        /// </summary>
-        internal static string MajorMinorRequirementShort {
-            get {
-                return ResourceManager.GetString("MajorMinorRequirementShort", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to You must specify exactly one version for option: {0}..
         /// </summary>
         internal static string MoreThanOneVersionSpecifiedExceptionMessageFormat {
@@ -360,6 +351,15 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Maybe needed for Visual Studio{0}. Specify individually or use —force to remove.
+        /// </summary>
+        internal static string RequirementExplainationString {
+            get {
+                return ResourceManager.GetString("RequirementExplainationString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified version is not found: &quot;{0}&quot;..
         /// </summary>
         internal static string SpecifiedVersionNotFoundExceptionMessageFormat {
@@ -414,7 +414,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes that have been superceded by higher patches..
+        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json..
         /// </summary>
         internal static string UninstallAllLowerPatchesOptionDescription {
             get {
@@ -432,7 +432,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview..
+        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview..
         /// </summary>
         internal static string UninstallAllPreviewsButLatestOptionDescription {
             get {
@@ -441,7 +441,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes that are marked as previews..
+        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes marked as previews..
         /// </summary>
         internal static string UninstallAllPreviewsOptionDescription {
             get {
@@ -585,20 +585,11 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio.
-        /// </summary>
-        internal static string UpperLimitRequirementLong {
-            get {
-                return ResourceManager.GetString("UpperLimitRequirementLong", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Cannot uninstall version {0} and above.
         /// </summary>
-        internal static string UpperLimitRequirementShort {
+        internal static string UpperLimitRequirement {
             get {
-                return ResourceManager.GetString("UpperLimitRequirementShort", resourceCulture);
+                return ResourceManager.GetString("UpperLimitRequirement", resourceCulture);
             }
         }
         
@@ -644,24 +635,6 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string VersionOptionDescription {
             get {
                 return ResourceManager.GetString("VersionOptionDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Required by Visual Studio 2017, Visual Studio will break without this SDK.
-        /// </summary>
-        internal static string VisualStudioRequirementLong {
-            get {
-                return ResourceManager.GetString("VisualStudioRequirementLong", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Required by Visual Studio 2017.
-        /// </summary>
-        internal static string VisualStudioRequirementShort {
-            get {
-                return ResourceManager.GetString("VisualStudioRequirementShort", resourceCulture);
             }
         }
         

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -127,11 +127,20 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Execute the command including unreccommended unisntallations..
+        ///   Looks up a localized string similar to Force removal of versions that might be used by Visual Studio or SDK..
         /// </summary>
-        internal static string ForceOptionDescription {
+        internal static string ForceOptionDescriptionMac {
             get {
-                return ResourceManager.GetString("ForceOptionDescription", resourceCulture);
+                return ResourceManager.GetString("ForceOptionDescriptionMac", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Force removal of versions that might be used by Visual Studio..
+        /// </summary>
+        internal static string ForceOptionDescriptionWindows {
+            get {
+                return ResourceManager.GetString("ForceOptionDescriptionWindows", resourceCulture);
             }
         }
         
@@ -186,6 +195,17 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string ListCommandHostingBundleHeader {
             get {
                 return ResourceManager.GetString("ListCommandHostingBundleHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+        ///.
+        /// </summary>
+        internal static string ListCommandOutput {
+            get {
+                return ResourceManager.GetString("ListCommandOutput", resourceCulture);
             }
         }
         
@@ -351,7 +371,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Maybe needed for Visual Studio{0}. Specify individually or use —force to remove.
+        ///   Looks up a localized string similar to Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove.
         /// </summary>
         internal static string RequirementExplainationString {
             get {
@@ -504,7 +524,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The specified version to uninstall. You may list several versions, and response files are supported..
+        ///   Looks up a localized string similar to The specified version to uninstall. You may list several versions. Response files are supported..
         /// </summary>
         internal static string UninstallNoOptionArgumentDescription {
             get {
@@ -522,11 +542,20 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall..
+        ///   Looks up a localized string similar to Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall..
         /// </summary>
-        internal static string UninstallNoOptionDescription {
+        internal static string UninstallNoOptionDescriptionMac {
             get {
-                return ResourceManager.GetString("UninstallNoOptionDescription", resourceCulture);
+                return ResourceManager.GetString("UninstallNoOptionDescriptionMac", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall..
+        /// </summary>
+        internal static string UninstallNoOptionDescriptionWindows {
+            get {
+                return ResourceManager.GetString("UninstallNoOptionDescriptionWindows", resourceCulture);
             }
         }
         
@@ -630,7 +659,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Display .NET Core Uninstall Tool Version Information..
+        ///   Looks up a localized string similar to Display .NET Core Uninstall Tool version information..
         /// </summary>
         internal static string VersionOptionDescription {
             get {

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -118,7 +118,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         ///
         ///To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
         ///
-        ///Run this command as administrator, and take out the -—dry-run option to remove these items..
+        ///Run as administrator and use the remove command to remove these items..
         /// </summary>
         internal static string DryRunOutputFormat {
             get {
@@ -316,6 +316,32 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to 
+        ///{0}: {1}
+        ///
+        ///Uninstalling this item will cause Visual Studio to break.
+        ///
+        ///Are you sure you want to continue? [Y/n] .
+        /// </summary>
+        internal static string RequiredBundleConfirmationPromptOutputFormat {
+            get {
+                return ResourceManager.GetString("RequiredBundleConfirmationPromptOutputFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///Warning: {0}: {1}
+        ///Uninstalling this item will cause Visual Studio to break.
+        ///.
+        /// </summary>
+        internal static string RequiredBundleConfirmationPromptWarningFormat {
+            get {
+                return ResourceManager.GetString("RequiredBundleConfirmationPromptWarningFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified version is not found: &quot;{0}&quot;..
         /// </summary>
         internal static string SpecifiedVersionNotFoundExceptionMessageFormat {
@@ -492,6 +518,15 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string UninstallNormalVerbosityFormat {
             get {
                 return ResourceManager.GetString("UninstallNormalVerbosityFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above..
+        /// </summary>
+        internal static string UninstallNotAllowedExceptionFormat {
+            get {
+                return ResourceManager.GetString("UninstallNotAllowedExceptionFormat", resourceCulture);
             }
         }
         

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -267,7 +267,7 @@
   <data name="ListX86OptionDescription" xml:space="preserve">
     <value>List x86 .NET Core SDKs or Runtimes.</value>
   </data>
-  <data name="DryRunOptionDescription" xml:space="preserve">
+  <data name="DryRunCommandDescription" xml:space="preserve">
     <value>Display .NET Core SDKs and Runtimes that will be removed.</value>
   </data>
   <data name="YesOptionDescription" xml:space="preserve">
@@ -294,7 +294,7 @@ Do you want to continue? [Y/n] </value>
   <data name="ConfirmationPromptInvalidExceptionMessage" xml:space="preserve">
     <value>Allowed values are "Y" and "n".</value>
   </data>
-  <data name="ListIncludeRequiredOptionDescription" xml:space="preserve">
-    <value>Include .NET Core SDKs that cannot be uninstalled.</value>
+  <data name="RemoveCommandDescription" xml:space="preserve">
+    <value>Remove the specified .NET Core SDKs or Runtimes.</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -190,13 +190,13 @@
     <value>Remove .NET Core SDKs or Runtimes that match the specified `major.minor` version.</value>
   </data>
   <data name="UninstallNoOptionArgumentDescription" xml:space="preserve">
-    <value>The specified version to uninstall. You may list several versions, and response files are supported.</value>
+    <value>The specified version to uninstall. You may list several versions. Response files are supported.</value>
   </data>
   <data name="UninstallNoOptionArgumentName" xml:space="preserve">
     <value>VERSION</value>
   </data>
-  <data name="UninstallNoOptionDescription" xml:space="preserve">
-    <value>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</value>
+  <data name="UninstallNoOptionDescriptionWindows" xml:space="preserve">
+    <value>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</value>
   </data>
   <data name="VerbosityOptionArgumentName" xml:space="preserve">
     <value>LEVEL</value>
@@ -315,15 +315,26 @@ Uninstalling this item will cause Visual Studio to break.
 </value>
   </data>
   <data name="VersionOptionDescription" xml:space="preserve">
-    <value>Display .NET Core Uninstall Tool Version Information.</value>
+    <value>Display .NET Core Uninstall Tool version information.</value>
   </data>
   <data name="UpperLimitRequirement" xml:space="preserve">
     <value>Cannot uninstall version {0} and above</value>
   </data>
   <data name="RequirementExplainationString" xml:space="preserve">
-    <value>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</value>
+    <value>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</value>
   </data>
-  <data name="ForceOptionDescription" xml:space="preserve">
-    <value>Execute the command including unreccommended unisntallations.</value>
+  <data name="ForceOptionDescriptionWindows" xml:space="preserve">
+    <value>Force removal of versions that might be used by Visual Studio.</value>
+  </data>
+  <data name="ForceOptionDescriptionMac" xml:space="preserve">
+    <value>Force removal of versions that might be used by Visual Studio or SDK.</value>
+  </data>
+  <data name="ListCommandOutput" xml:space="preserve">
+    <value>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</value>
+  </data>
+  <data name="UninstallNoOptionDescriptionMac" xml:space="preserve">
+    <value>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -166,16 +166,16 @@
     <value>Remove .NET Core SDKs or Runtimes, except those specified.</value>
   </data>
   <data name="UninstallAllLowerPatchesOptionDescription" xml:space="preserve">
-    <value>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</value>
+    <value>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</value>
   </data>
   <data name="UninstallAllOptionDescription" xml:space="preserve">
     <value>Remove all .NET Core SDKs or Runtimes.</value>
   </data>
   <data name="UninstallAllPreviewsButLatestOptionDescription" xml:space="preserve">
-    <value>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</value>
+    <value>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</value>
   </data>
   <data name="UninstallAllPreviewsOptionDescription" xml:space="preserve">
-    <value>Remove .NET Core SDKs or Runtimes that are marked as previews.</value>
+    <value>Remove .NET Core SDKs or Runtimes marked as previews.</value>
   </data>
   <data name="UninstallationFailedExceptionMessageFormat" xml:space="preserve">
     <value>Timeout during uninstall: {0}.</value>
@@ -317,22 +317,13 @@ Uninstalling this item will cause Visual Studio to break.
   <data name="VersionOptionDescription" xml:space="preserve">
     <value>Display .NET Core Uninstall Tool Version Information.</value>
   </data>
-  <data name="MajorMinorRequirementLong" xml:space="preserve">
-    <value>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</value>
-  </data>
-  <data name="MajorMinorRequirementShort" xml:space="preserve">
-    <value>Required for {0}.{1} Applications</value>
-  </data>
-  <data name="UpperLimitRequirementLong" xml:space="preserve">
-    <value>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</value>
-  </data>
-  <data name="UpperLimitRequirementShort" xml:space="preserve">
+  <data name="UpperLimitRequirement" xml:space="preserve">
     <value>Cannot uninstall version {0} and above</value>
   </data>
-  <data name="VisualStudioRequirementLong" xml:space="preserve">
-    <value>Required by Visual Studio 2017, Visual Studio will break without this SDK</value>
+  <data name="RequirementExplainationString" xml:space="preserve">
+    <value>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</value>
   </data>
-  <data name="VisualStudioRequirementShort" xml:space="preserve">
-    <value>Required by Visual Studio 2017</value>
+  <data name="ForceOptionDescription" xml:space="preserve">
+    <value>Execute the command including unreccommended unisntallations.</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -281,7 +281,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</value>
+Run as administrator and use the remove command to remove these items.</value>
   </data>
   <data name="ConfirmationPromptOutputFormat" xml:space="preserve">
     <value>The following items will be removed:
@@ -296,5 +296,22 @@ Do you want to continue? [Y/n] </value>
   </data>
   <data name="RemoveCommandDescription" xml:space="preserve">
     <value>Remove the specified .NET Core SDKs or Runtimes.</value>
+  </data>
+  <data name="UninstallNotAllowedExceptionFormat" xml:space="preserve">
+    <value>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</value>
+  </data>
+  <data name="RequiredBundleConfirmationPromptOutputFormat" xml:space="preserve">
+    <value>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </value>
+  </data>
+  <data name="RequiredBundleConfirmationPromptWarningFormat" xml:space="preserve">
+    <value>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -256,10 +256,10 @@
     <value>List .NET Core Runtime &amp; Hosting Bundles.</value>
   </data>
   <data name="ListRuntimeOptionDescription" xml:space="preserve">
-    <value>List .NET Core Runtimes.</value>
+    <value>List .NET Core Runtimes that can be uninstalled.</value>
   </data>
   <data name="ListSdkOptionDescription" xml:space="preserve">
-    <value>List .NET Core SDKs.</value>
+    <value>List .NET Core SDKs that can be uninstalled.</value>
   </data>
   <data name="ListX64OptionDescription" xml:space="preserve">
     <value>List x64 .NET Core SDKs or Runtimes.</value>
@@ -281,7 +281,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</value>
+Run as administrator and use the remove command to uninstall these items.</value>
   </data>
   <data name="ConfirmationPromptOutputFormat" xml:space="preserve">
     <value>The following items will be removed:
@@ -313,5 +313,26 @@ Are you sure you want to continue? [Y/n] </value>
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </value>
+  </data>
+  <data name="VersionOptionDescription" xml:space="preserve">
+    <value>Display .NET Core Uninstall Tool Version Information.</value>
+  </data>
+  <data name="MajorMinorRequirementLong" xml:space="preserve">
+    <value>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</value>
+  </data>
+  <data name="MajorMinorRequirementShort" xml:space="preserve">
+    <value>Required for {0}.{1} Applications</value>
+  </data>
+  <data name="UpperLimitRequirementLong" xml:space="preserve">
+    <value>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</value>
+  </data>
+  <data name="UpperLimitRequirementShort" xml:space="preserve">
+    <value>Cannot uninstall version {0} and above</value>
+  </data>
+  <data name="VisualStudioRequirementLong" xml:space="preserve">
+    <value>Required by Visual Studio 2017, Visual Studio will break without this SDK</value>
+  </data>
+  <data name="VisualStudioRequirementShort" xml:space="preserve">
+    <value>Required by Visual Studio 2017</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/MacOs/SupportedBundleTypeConfigs.cs
+++ b/src/dotnet-core-uninstall/MacOs/SupportedBundleTypeConfigs.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
 {
     internal static class SupportedBundleTypeConfigs
     {
-        private static readonly Func<IDictionary<Bundle, string>, GridView> _gridViewGeneratorWithArch = bundles =>
+        private static readonly Func<IDictionary<Bundle, string>, bool, GridView> _gridViewGeneratorWithArch = (bundles, verbose) =>
         {
             var gridView = new GridView();
 

--- a/src/dotnet-core-uninstall/MacOs/SupportedBundleTypeConfigs.cs
+++ b/src/dotnet-core-uninstall/MacOs/SupportedBundleTypeConfigs.cs
@@ -22,7 +22,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
                 gridView.SetChild(new ContentView(string.Empty), 0, index);
                 gridView.SetChild(new ContentView(bundle.Key.Version.ToString()), 1, index);
                 gridView.SetChild(new ContentView($"({bundle.Key.Arch.ToString().ToLower()})"), 2, index);
-                gridView.SetChild(new ContentView(bundle.Value), 3, index);
+                gridView.SetChild(new ContentView(bundle.Value.Equals(string.Empty) ? string.Empty : $"[{bundle.Value}]"), 3, index);
             }
 
             return gridView;

--- a/src/dotnet-core-uninstall/Shared/Commands/CommandBundleFilter.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/CommandBundleFilter.cs
@@ -11,6 +11,7 @@ using System.Linq;
 using System.CommandLine;
 using Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning;
 using NuGet.Versioning;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Configs.Verbosity;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
 {
@@ -75,7 +76,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             }
             else
             {
-                return OptionFilterers.OptionFiltererDictionary[option.Name].Filter(
+                return OptionFilterers.OptionFiltererDictionary[option].Filter(
                     parseResult,
                     option,
                     bundles,
@@ -88,7 +89,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
         {
             var allBundles = GetAllBundles();
             var filteredBundles = GetFilteredBundles(allBundles);
-            return VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(allBundles)
+            return VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(allBundles, CommandLineConfigs.IsVerbosityLevelAboveNormal())
                     .Where(pair => filteredBundles.Contains(pair.Key))
                     .ToDictionary(i => i.Key, i => i.Value);
         }

--- a/src/dotnet-core-uninstall/Shared/Commands/CommandBundleFilter.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/CommandBundleFilter.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Configs;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
+using Microsoft.DotNet.Tools.Uninstall.Windows;
+using System.Reflection;
+using Microsoft.DotNet.Tools.Uninstall.MacOs;
+using System.Linq;
+
+namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
+{
+    internal static class CommandBundleFilter
+    {
+        private static readonly Lazy<string> _assemblyVersion =
+            new Lazy<string>(() =>
+            {
+                var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+                var assemblyVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
+                if (assemblyVersionAttribute == null)
+                {
+                    return assembly.GetName().Version.ToString();
+                }
+                else
+                {
+                    return assemblyVersionAttribute.InformationalVersion;
+                }
+            });
+
+        private static IEnumerable<Bundle> GetAllBundles()
+        {
+            if (RuntimeInfo.RunningOnWindows)
+            {
+                return RegistryQuery.GetInstalledBundles();
+            }
+            else if (RuntimeInfo.RunningOnOSX)
+            {
+                return FileSystemExplorer.GetInstalledBundles();
+            }
+            else
+            {
+                throw new OperatingSystemNotSupportedException();
+            }
+        }
+
+        public static IEnumerable<Bundle> GetFilteredBundles()
+        {
+            var bundles = GetAllBundles();
+            var option = CommandLineConfigs.CommandLineParseResult.CommandResult.GetUninstallMainOption();
+            var typeSelection = CommandLineConfigs.CommandLineParseResult.CommandResult.GetTypeSelection();
+            var archSelection = CommandLineConfigs.CommandLineParseResult.CommandResult.GetArchSelection();
+
+            if (option == null)
+            {
+                if (CommandLineConfigs.CommandLineParseResult.CommandResult.Tokens.Count == 0)
+                {
+                    throw new RequiredArgMissingForUninstallCommandException();
+                }
+
+                return OptionFilterers.UninstallNoOptionFilterer.Filter(
+                    CommandLineConfigs.CommandLineParseResult.CommandResult.Tokens.Select(t => t.Value),
+                    bundles,
+                    typeSelection,
+                    archSelection);
+            }
+            else
+            {
+                return OptionFilterers.OptionFiltererDictionary[option.Name].Filter(
+                    CommandLineConfigs.CommandLineParseResult,
+                    option,
+                    bundles,
+                    typeSelection,
+                    archSelection);
+            }
+        }
+
+        public static void HandleVersionOption()
+        {
+            if (CommandLineConfigs.CommandLineParseResult.CommandResult.OptionResult(CommandLineConfigs.VersionOption.Name) != null)
+            {
+                Console.WriteLine(_assemblyVersion.Value);
+                Environment.Exit(0);
+            }
+        }
+    }
+}

--- a/src/dotnet-core-uninstall/Shared/Commands/DryRunCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/DryRunCommandExec.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
+using System.Linq;
+
+namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
+{
+    internal static class DryRunCommandExec
+    {
+        public static void Execute()
+        {
+            CommandBundleFilter.HandleVersionOption();
+
+            var filtered = CommandBundleFilter.GetFilteredBundles();
+            TryIt(filtered);
+        }
+
+        private static void TryIt(IEnumerable<Bundle> bundles)
+        {
+            var displayNames = string.Join("\n", bundles.Select(bundle => $"  {bundle.DisplayName}"));
+            Console.WriteLine(string.Format(LocalizableStrings.DryRunOutputFormat, displayNames));
+        }
+    }
+}

--- a/src/dotnet-core-uninstall/Shared/Commands/DryRunCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/DryRunCommandExec.cs
@@ -11,14 +11,21 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
         {
             CommandBundleFilter.HandleVersionOption();
 
-            var filtered = CommandBundleFilter.GetFilteredBundles();
+            var filtered = CommandBundleFilter.GetFilteredWithRequirementStrings();
             TryIt(filtered);
         }
 
-        private static void TryIt(IEnumerable<Bundle> bundles)
+        private static void TryIt(IDictionary<Bundle, string> bundles)
         {
-            var displayNames = string.Join("\n", bundles.Select(bundle => $"  {bundle.DisplayName}"));
+            var displayNames = string.Join("\n", bundles.Select(bundle => $"  {bundle.Key.DisplayName}"));
             Console.WriteLine(string.Format(LocalizableStrings.DryRunOutputFormat, displayNames));
+
+            foreach (var pair in bundles.Where(b => !b.Value.Equals(string.Empty)))
+            {
+                Console.ForegroundColor = ConsoleColor.Red;
+                Console.Write(string.Format(LocalizableStrings.RequiredBundleConfirmationPromptWarningFormat, pair.Key.DisplayName, pair.Value));
+                Console.ResetColor();
+            }
         }
     }
 }

--- a/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using Microsoft.DotNet.Tools.Uninstall.MacOs;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Configs;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Configs.Verbosity;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
 using Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning;
@@ -40,8 +41,12 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             IEnumerable<Bundle> bundles,
             IEnumerable<BundleTypePrintInfo> supportedBundleTypes)
         {
+            Console.WriteLine(LocalizableStrings.ListCommandOutput);
+
             var listCommandParseResult = CommandLineConfigs.ListCommand.Parse(Environment.GetCommandLineArgs());
 
+            var verbose = listCommandParseResult.CommandResult.GetVerbosityLevel().Equals(VerbosityLevel.Detailed) ||
+                listCommandParseResult.CommandResult.GetVerbosityLevel().Equals(VerbosityLevel.Diagnostic);
             var typeSelection = listCommandParseResult.CommandResult.GetTypeSelection();
             var archSelection = listCommandParseResult.CommandResult.GetArchSelection();
 
@@ -62,7 +67,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
                     var uninstallMap = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(filteredBundlesByType);
 
                     stackView.Add(new ContentView(bundleType.Header));
-                    stackView.Add(bundleType.GridViewGenerator.Invoke(uninstallMap));
+                    stackView.Add(bundleType.GridViewGenerator.Invoke(uninstallMap, verbose));
                     stackView.Add(new ContentView(string.Empty));
 
                     footnotes.AddRange(filteredBundlesByType

--- a/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
@@ -59,8 +59,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
                     var filteredBundlesByType = bundleType
                         .Filter(filteredBundlesByArch);
 
-                    var uninstallMap = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(filteredBundlesByType, 
-                        CommandLineConfigs.IsVerbosityLevelAboveNormal());
+                    var uninstallMap = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(filteredBundlesByType);
 
                     stackView.Add(new ContentView(bundleType.Header));
                     stackView.Add(bundleType.GridViewGenerator.Invoke(uninstallMap));

--- a/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
@@ -59,7 +59,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
                     var filteredBundlesByType = bundleType
                         .Filter(filteredBundlesByArch);
 
-                    var uninstallMap = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(filteredBundlesByType);
+                    var uninstallMap = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(filteredBundlesByType, 
+                        CommandLineConfigs.IsVerbosityLevelAboveNormal());
 
                     stackView.Add(new ContentView(bundleType.Header));
                     stackView.Add(bundleType.GridViewGenerator.Invoke(uninstallMap));

--- a/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
@@ -42,8 +42,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
         {
             var listCommandParseResult = CommandLineConfigs.ListCommand.Parse(Environment.GetCommandLineArgs());
 
-            var uninstallableBundles = VisualStudioSafeVersionsExtractor.GetUninstallableBundles(bundles);
-
             var typeSelection = listCommandParseResult.CommandResult.GetTypeSelection();
             var archSelection = listCommandParseResult.CommandResult.GetArchSelection();
 
@@ -59,14 +57,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
                 if (typeSelection.HasFlag(bundleType.Type))
                 {
                     var filteredBundlesByType = bundleType
-                        .Filter(filteredBundlesByArch)
-                        .OrderByDescending(bundle => bundle);
+                        .Filter(filteredBundlesByArch);
 
-                    var uninstallMap = filteredBundlesByType
-                        .Select(bundle => uninstallableBundles.Contains(bundle) ?
-                        new KeyValuePair<Bundle, string>(bundle, string.Empty) :
-                        new KeyValuePair<Bundle, string>(bundle, "[Not Uninstallable]"))
-                        .ToDictionary(i => i.Key, i => i.Value);
+                    var uninstallMap = VisualStudioSafeVersionsExtractor.GetListCommandUninstallableStrings(filteredBundlesByType);
 
                     stackView.Add(new ContentView(bundleType.Header));
                     stackView.Add(bundleType.GridViewGenerator.Invoke(uninstallMap));

--- a/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
@@ -59,7 +59,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
                     var filteredBundlesByType = bundleType
                         .Filter(filteredBundlesByArch);
 
-                    var uninstallMap = VisualStudioSafeVersionsExtractor.GetListCommandUninstallableStrings(filteredBundlesByType);
+                    var uninstallMap = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(filteredBundlesByType);
 
                     stackView.Add(new ContentView(bundleType.Header));
                     stackView.Add(bundleType.GridViewGenerator.Invoke(uninstallMap));

--- a/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
@@ -48,7 +48,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
                     throw new NotAdminException();
                 }
 
-                if (AskIt(filtered))
+                if (AskItAndReturnUserAnswer(filtered))
                 {
                     if (AskWithWarningsForRequiredBundles(filtered))
                     {
@@ -207,16 +207,20 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             return args;
         }
 
-        private static bool AskIt(IDictionary<Bundle, string> bundles)
+        private static bool AskItAndReturnUserAnswer(IDictionary<Bundle, string> bundles)
         {
             var displayNames = string.Join("\n", bundles.Select(bundle => $"  {bundle.Key.DisplayName}"));
             Console.Write(string.Format(LocalizableStrings.ConfirmationPromptOutputFormat, displayNames));
 
             var response = Console.ReadLine().Trim().ToUpper();
 
-            if (response.Equals("Y") || response.Equals("N"))
+            if (response.Equals("Y"))
             {
-                return response.Equals("Y");
+                return true;
+            }
+            else if (response.Equals("N"))
+            {
+                return false;
             }
             else
             {

--- a/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
@@ -4,9 +4,6 @@ using Microsoft.DotNet.Tools.Uninstall.Shared.Configs;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
-using Microsoft.DotNet.Tools.Uninstall.Windows;
-using System.Reflection;
-using Microsoft.DotNet.Tools.Uninstall.MacOs;
 using System.Linq;
 using System.Diagnostics;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Configs.Verbosity;
@@ -29,32 +26,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             [MarshalAs(UnmanagedType.LPWStr)] string lpCmdLine,
             out int pNumArgs);
 
-        private static readonly Lazy<string> _assemblyVersion =
-            new Lazy<string>(() =>
-            {
-                var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
-                var assemblyVersionAttribute = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>();
-                if (assemblyVersionAttribute == null)
-                {
-                    return assembly.GetName().Version.ToString();
-                }
-                else
-                {
-                    return assemblyVersionAttribute.InformationalVersion;
-                }
-            });
-
         public static void Execute()
         {
-            HandleVersionOption();
+            CommandBundleFilter.HandleVersionOption();
 
-            var filtered = GetFilteredBundles(GetAllBundles());
+            var filtered = CommandBundleFilter.GetFilteredBundles();
 
-            if (CommandLineConfigs.CommandLineParseResult.RootCommandResult.OptionResult(CommandLineConfigs.DryRunOption.Name) != null)
-            {
-                TryIt(filtered);
-            }
-            else if (CommandLineConfigs.CommandLineParseResult.RootCommandResult.OptionResult(CommandLineConfigs.YesOption.Name) != null)
+            if (CommandLineConfigs.CommandLineParseResult.CommandResult.OptionResult(CommandLineConfigs.YesOption.Name) != null)
             {
                 if (!IsAdmin())
                 {
@@ -74,55 +52,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             }
         }
 
-        private static IEnumerable<Bundle> GetAllBundles()
-        {
-            if (RuntimeInfo.RunningOnWindows)
-            {
-                return RegistryQuery.GetInstalledBundles();
-            }
-            else if (RuntimeInfo.RunningOnOSX)
-            {
-                return FileSystemExplorer.GetInstalledBundles();
-            }
-            else
-            {
-                throw new OperatingSystemNotSupportedException();
-            }
-        }
-
-        private static IEnumerable<Bundle> GetFilteredBundles(IEnumerable<Bundle> bundles)
-        {
-            var option = CommandLineConfigs.CommandLineParseResult.RootCommandResult.GetUninstallMainOption();
-            var typeSelection = CommandLineConfigs.CommandLineParseResult.RootCommandResult.GetTypeSelection();
-            var archSelection = CommandLineConfigs.CommandLineParseResult.RootCommandResult.GetArchSelection();
-
-            if (option == null)
-            {
-                if (CommandLineConfigs.CommandLineParseResult.RootCommandResult.Tokens.Count == 0)
-                {
-                    throw new RequiredArgMissingForUninstallCommandException();
-                }
-
-                return OptionFilterers.UninstallNoOptionFilterer.Filter(
-                    CommandLineConfigs.CommandLineParseResult.RootCommandResult.Tokens.Select(t => t.Value),
-                    bundles,
-                    typeSelection,
-                    archSelection);
-            }
-            else
-            {
-                return OptionFilterers.OptionFiltererDictionary[option].Filter(
-                    CommandLineConfigs.CommandLineParseResult,
-                    option,
-                    bundles,
-                    typeSelection,
-                    archSelection);
-            }
-        }
-
         private static void DoIt(IEnumerable<Bundle> bundles)
         {
-            var verbosityLevel = CommandLineConfigs.CommandLineParseResult.RootCommandResult.GetVerbosityLevel();
+            var verbosityLevel = CommandLineConfigs.CommandLineParseResult.CommandResult.GetVerbosityLevel();
             var verbosityLogger = new VerbosityLogger(verbosityLevel);
 
             var canceled = false;
@@ -269,12 +201,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             return args;
         }
 
-        private static void TryIt(IEnumerable<Bundle> bundles)
-        {
-            var displayNames = string.Join("\n", bundles.Select(bundle => $"  {bundle.DisplayName}"));
-            Console.WriteLine(string.Format(LocalizableStrings.DryRunOutputFormat, displayNames));
-        }
-
         private static void AskIt(IEnumerable<Bundle> bundles)
         {
             var displayNames = string.Join("\n", bundles.Select(bundle => $"  {bundle.DisplayName}"));
@@ -293,15 +219,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             else
             {
                 throw new ConfirmationPromptInvalidException();
-            }
-        }
-
-        private static void HandleVersionOption()
-        {
-            if (CommandLineConfigs.CommandLineParseResult.RootCommandResult.OptionResult(CommandLineConfigs.VersionOption.Name) != null)
-            {
-                Console.WriteLine(_assemblyVersion.Value);
-                Environment.Exit(0);
             }
         }
     }

--- a/src/dotnet-core-uninstall/Shared/Configs/BundleTypePrintInfo.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/BundleTypePrintInfo.cs
@@ -11,10 +11,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
         public abstract BundleType Type { get; }
 
         public string Header { get; }
-        public Func<IDictionary<Bundle, string>, GridView> GridViewGenerator { get; }
+        public Func<IDictionary<Bundle, string>, bool, GridView> GridViewGenerator { get; }
         public string OptionName { get; }
 
-        protected BundleTypePrintInfo(string header, Func<IDictionary<Bundle, string>, GridView> gridViewGenerator, string optionName)
+        protected BundleTypePrintInfo(string header, Func<IDictionary<Bundle, string>, bool, GridView> gridViewGenerator, string optionName)
         {
             Header = header ?? throw new ArgumentNullException();
             GridViewGenerator = gridViewGenerator ?? throw new ArgumentNullException();
@@ -29,7 +29,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
     {
         public override BundleType Type => new TBundleVersion().Type;
 
-        public BundleTypePrintInfo(string header, Func<IDictionary<Bundle, string>, GridView> gridViewGenerator, string optionName) :
+        public BundleTypePrintInfo(string header, Func<IDictionary<Bundle, string>, bool, GridView> gridViewGenerator, string optionName) :
             base(header, gridViewGenerator, optionName)
         { }
 

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -118,6 +118,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             new[] { "--yes", "-y" },
             LocalizableStrings.YesOptionDescription);
 
+        public static readonly Option ForceOption = new Option(
+            "--force",
+            LocalizableStrings.ForceOptionDescription);
+
         public static readonly Option[] UninstallFilterBundlesOptions = new Option[]
         {
             UninstallAllOption,
@@ -187,7 +191,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             RemoveAuxOptions = UninstallBundleTypeOptions
                 .Where(option => supportedBundleTypeNames.Contains(option.Name))
                 .Concat(AdditionalUninstallOptions)
-                .Append(YesOption);
+                .Append(YesOption)
+                .Append(ForceOption);
             if (RuntimeInfo.RunningOnWindows)
             {
                 RemoveAuxOptions = RemoveAuxOptions.Concat(ArchUninstallOptions);
@@ -207,9 +212,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
             ListAuxOptions = ListBundleTypeOptions
                 .Where(option => supportedBundleTypeNames.Contains(option.Name))
-                .Append(VerbosityOption)
-                .Append(ListX64Option)
-                .Append(ListX86Option);
+                .Append(VerbosityOption);
+            if (RuntimeInfo.RunningOnWindows)
+            {
+                ListAuxOptions = ListAuxOptions
+                    .Append(ListX64Option)
+                    .Append(ListX86Option);
+            }
             AssignOptionsToCommand(ListCommand, ListAuxOptions);
 
             ListCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => ListCommandExec.Execute()));
@@ -301,12 +310,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             {
                 throw new VerbosityLevelInvalidException();
             }
-        }
-
-        public static bool IsVerbosityLevelAboveNormal()
-        {
-            return CommandLineConfigs.CommandLineParseResult.CommandResult.GetVerbosityLevel().Equals(VerbosityLevel.Detailed)
-                || CommandLineConfigs.CommandLineParseResult.CommandResult.GetVerbosityLevel().Equals(VerbosityLevel.Diagnostic);
         }
 
         private static void AssignOptionsToCommand(Command command, IEnumerable<Option> options, bool addVersionArgument = false)

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -12,27 +12,51 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 {
     internal static class CommandLineConfigs
     {
+        private static readonly string ListCommandName = "list";
+        private static readonly string DryRunCommandName = "dry-run";
+        private static readonly string WhatIfCommandName = "whatif";
+        private static readonly string RemoveCommandName = "remove";
+
+        public static readonly RootCommand UninstallRootCommand = new RootCommand(
+            LocalizableStrings.UninstallNoOptionDescription);
+
+        public static readonly Command ListCommand = new Command(
+            ListCommandName,
+            LocalizableStrings.ListCommandDescription);
+
+        public static readonly Command DryRunCommand = new Command(
+            DryRunCommandName,
+            LocalizableStrings.DryRunCommandDescription);
+
+        public static readonly Command WhatIfCommand = new Command(
+            WhatIfCommandName,
+            LocalizableStrings.DryRunCommandDescription);
+
+        public static readonly Command RemoveCommand = new Command(
+           RemoveCommandName,
+            LocalizableStrings.RemoveCommandDescription);
+
+
         public static readonly string SdkOptionName = "sdk";
         public static readonly string RuntimeOptionName = "runtime";
         public static readonly string AspNetRuntimeOptionName = "aspnet-runtime";
         public static readonly string HostingBundleOptionName = "hosting-bundle";
         public static readonly string X64OptionName = "x64";
         public static readonly string X86OptionName = "x86";
-        public static readonly string ListCommandName = "list";
 
-        public static readonly Option UninstallAllOption = new Option(
+        public static Option UninstallAllOption => new Option(
             "--all",
             LocalizableStrings.UninstallAllOptionDescription);
 
-        public static readonly Option UninstallAllLowerPatchesOption = new Option(
+        public static Option UninstallAllLowerPatchesOption => new Option(
             "--all-lower-patches",
             LocalizableStrings.UninstallAllLowerPatchesOptionDescription);
 
-        public static readonly Option UninstallAllButLatestOption = new Option(
+        public static Option UninstallAllButLatestOption => new Option(
             "--all-but-latest",
             LocalizableStrings.UninstallAllButLatestOptionDescription);
 
-        public static readonly Option UninstallAllButOption = new Option(
+        public static Option UninstallAllButOption => new Option(
             "--all-but",
             LocalizableStrings.UninstallAllButOptionDescription)
         {
@@ -42,7 +66,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             }
         };
 
-        public static readonly Option UninstallAllBelowOption = new Option(
+        public static Option UninstallAllBelowOption => new Option(
             "--all-below",
             LocalizableStrings.UninstallAllBelowOptionDescription)
         {
@@ -52,15 +76,15 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             }
         };
 
-        public static readonly Option UninstallAllPreviewsOption = new Option(
+        public static Option UninstallAllPreviewsOption => new Option(
             "--all-previews",
             LocalizableStrings.UninstallAllPreviewsOptionDescription);
 
-        public static readonly Option UninstallAllPreviewsButLatestOption = new Option(
+        public static Option UninstallAllPreviewsButLatestOption => new Option(
             "--all-previews-but-latest",
             LocalizableStrings.UninstallAllPreviewsButLatestOptionDescription);
 
-        public static readonly Option UninstallMajorMinorOption = new Option(
+        public static Option UninstallMajorMinorOption => new Option(
             "--major-minor",
             LocalizableStrings.UninstallMajorMinorOptionDescription)
         {
@@ -70,7 +94,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             }
         };
 
-        public static readonly Option VerbosityOption = new Option(
+        public static Option VerbosityOption => new Option(
             new[] { "--verbosity", "-v" },
             LocalizableStrings.VerbosityOptionDescription)
         {
@@ -80,69 +104,24 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             }
         };
 
-        public static readonly Option UninstallSdkOption = new Option(
-            $"--{SdkOptionName}",
-            LocalizableStrings.UninstallSdkOptionDescription);
-
-        public static readonly Option UninstallRuntimeOption = new Option(
-            $"--{RuntimeOptionName}",
-            LocalizableStrings.UninstallRuntimeOptionDescription);
-
-        public static readonly Option UninstallAspNetRuntimeOption = new Option(
-            $"--{AspNetRuntimeOptionName}",
-            LocalizableStrings.UninstallAspNetRuntimeOptionDescription);
-
-        public static readonly Option UninstallHostingBundleOption = new Option(
-            $"--{HostingBundleOptionName}",
-            LocalizableStrings.UninstallHostingBundleOptionDescription);
-
-        public static readonly Option ListSdkOption = new Option(
-            $"--{SdkOptionName}",
-            LocalizableStrings.ListSdkOptionDescription);
-
-        public static readonly Option ListRuntimeOption = new Option(
-            $"--{RuntimeOptionName}",
-            LocalizableStrings.ListRuntimeOptionDescription);
-
-        public static readonly Option ListAspNetRuntimeOption = new Option(
-            $"--{AspNetRuntimeOptionName}",
-            LocalizableStrings.ListAspNetRuntimeOptionDescription);
-
-        public static readonly Option ListHostingBundleOption = new Option(
-            $"--{HostingBundleOptionName}",
-            LocalizableStrings.ListHostingBundleOptionDescription);
-
-        public static readonly Option UninstallX64Option = new Option(
-            $"--{X64OptionName}",
-            LocalizableStrings.UninstallX64OptionDescription);
-
-        public static readonly Option UninstallX86Option = new Option(
-            $"--{X86OptionName}",
-            LocalizableStrings.UninstallX86OptionDescription);
-
-        public static readonly Option ListX64Option = new Option(
+        public static Option ListX64Option => new Option(
             $"--{X64OptionName}",
             LocalizableStrings.ListX64OptionDescription);
 
-        public static readonly Option ListX86Option = new Option(
+        public static Option ListX86Option => new Option(
             $"--{X86OptionName}",
             LocalizableStrings.ListX86OptionDescription);
 
-        public static readonly Option VersionOption = new Option(
-            "--version")
+        public static Option VersionOption => new Option("--version")
         {
             IsHidden = true
         };
 
-        public static readonly Option DryRunOption = new Option(
-            "--dry-run",
-            LocalizableStrings.DryRunOptionDescription);
-
-        public static readonly Option YesOption = new Option(
+        public static Option YesOption => new Option(
             new[] { "--yes", "-y" },
             LocalizableStrings.YesOptionDescription);
 
-        public static readonly IEnumerable<Option> UninstallMainOptions = new Option[]
+        public static Option[] UninstallFilterBundlesOptions => new Option[]
         {
             UninstallAllOption,
             UninstallAllLowerPatchesOption,
@@ -151,17 +130,34 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             UninstallAllBelowOption,
             UninstallAllPreviewsOption,
             UninstallAllPreviewsButLatestOption,
-            UninstallMajorMinorOption,
+            UninstallMajorMinorOption
         };
 
-        public static readonly RootCommand UninstallRootCommand = new RootCommand(
-            LocalizableStrings.UninstallNoOptionDescription);
+        public static Option[] ListBundleTypeOptions => new Option[]
+        {
+            new Option($"--{SdkOptionName}", LocalizableStrings.ListSdkOptionDescription),
+            new Option($"--{RuntimeOptionName}", LocalizableStrings.ListRuntimeOptionDescription),
+            new Option($"--{AspNetRuntimeOptionName}", LocalizableStrings.ListAspNetRuntimeOptionDescription),
+            new Option($"--{HostingBundleOptionName}", LocalizableStrings.ListHostingBundleOptionDescription)
+        };
 
-        public static readonly Command ListCommand = new Command(
-            ListCommandName,
-            LocalizableStrings.ListCommandDescription);
+        public static Option[] UninstallBundleTypeOptions => new Option[]
+        {
+            new Option($"--{SdkOptionName}", LocalizableStrings.UninstallSdkOptionDescription),
+            new Option($"--{RuntimeOptionName}", LocalizableStrings.UninstallRuntimeOptionDescription),
+            new Option($"--{AspNetRuntimeOptionName}", LocalizableStrings.UninstallAspNetRuntimeOptionDescription),
+            new Option($"--{HostingBundleOptionName}", LocalizableStrings.UninstallHostingBundleOptionDescription)
+        };
 
-        public static readonly Dictionary<string, VerbosityLevel> VerbosityLevels = new Dictionary<string, VerbosityLevel>
+        public static Option[] AdditionalUninstallOptions => new Option[]
+        {
+            new Option($"--{X64OptionName}", LocalizableStrings.UninstallX64OptionDescription),
+            new Option($"--{X86OptionName}", LocalizableStrings.UninstallX86OptionDescription),
+            VerbosityOption,
+            VersionOption
+        };
+
+        public static readonly Dictionary<string, VerbosityLevel> VerbosityLevels = new Dictionary<string, VerbosityLevel> 
         {
             { "q", VerbosityLevel.Quiet }, { "quiet", VerbosityLevel.Quiet },
             { "m", VerbosityLevel.Minimal }, { "minimal", VerbosityLevel.Minimal },
@@ -171,74 +167,57 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
         };
 
         public static readonly ParseResult CommandLineParseResult;
-        public static readonly IEnumerable<Option> UninstallAuxOptions;
+        public static readonly IEnumerable<Option> RemoveAuxOptions;
+        public static readonly IEnumerable<Option> DryRunAuxOptions;
+        public static readonly IEnumerable<Option> WhatIfAuxOptions;
         public static readonly IEnumerable<Option> ListAuxOptions;
 
-        static CommandLineConfigs()
+        static CommandLineConfigs() 
         {
-            UninstallRootCommand.AddArgument(new Argument<IEnumerable<string>>
-            {
-                Name = LocalizableStrings.UninstallNoOptionArgumentName,
-                Description = LocalizableStrings.UninstallNoOptionArgumentDescription
-            });
-
             UninstallRootCommand.AddCommand(ListCommand);
+            UninstallRootCommand.AddCommand(DryRunCommand);
+            UninstallRootCommand.AddCommand(WhatIfCommand);
+            UninstallRootCommand.AddCommand(RemoveCommand);
 
             var supportedBundleTypeNames = SupportedBundleTypeConfigs.GetSupportedBundleTypes().Select(type => type.OptionName);
 
-            var supportedUninstallBundleTypeOptions = new Option[]
-            {
-                UninstallSdkOption,
-                UninstallRuntimeOption,
-                UninstallAspNetRuntimeOption,
-                UninstallHostingBundleOption
-            }
-            .Where(option => supportedBundleTypeNames.Contains(option.Name));
-
-            var supportedListBundleTypeOptions = new Option[]
-            {
-                ListSdkOption,
-                ListRuntimeOption,
-                ListAspNetRuntimeOption,
-                ListHostingBundleOption
-            }
-            .Where(option => supportedBundleTypeNames.Contains(option.Name));
-
-            UninstallAuxOptions = supportedUninstallBundleTypeOptions
-                .Append(VerbosityOption)
-                .Append(UninstallX64Option)
-                .Append(UninstallX86Option)
-                .Append(VersionOption)
-                .Append(DryRunOption)
+            RemoveAuxOptions = UninstallBundleTypeOptions
+                .Where(option => supportedBundleTypeNames.Contains(option.Name))
+                .Concat(AdditionalUninstallOptions)
                 .Append(YesOption);
+            AssignOptionsToCommand(RemoveCommand, RemoveAuxOptions
+                .Concat(UninstallFilterBundlesOptions), true);
 
-            ListAuxOptions = supportedListBundleTypeOptions
+            DryRunAuxOptions = UninstallBundleTypeOptions
+                .Where(option => supportedBundleTypeNames.Contains(option.Name))
+                .Concat(AdditionalUninstallOptions);
+            AssignOptionsToCommand(DryRunCommand, DryRunAuxOptions
+                .Concat(UninstallFilterBundlesOptions), true);
+
+            WhatIfAuxOptions = UninstallBundleTypeOptions
+                .Where(option => supportedBundleTypeNames.Contains(option.Name))
+                .Concat(AdditionalUninstallOptions);
+            AssignOptionsToCommand(WhatIfCommand, WhatIfAuxOptions
+                .Concat(UninstallFilterBundlesOptions), true);
+
+            ListAuxOptions = ListBundleTypeOptions
+                .Where(option => supportedBundleTypeNames.Contains(option.Name))
                 .Append(VerbosityOption)
                 .Append(ListX64Option)
                 .Append(ListX86Option);
-
-            foreach (var option in UninstallMainOptions
-                .Concat(UninstallAuxOptions)
-                .OrderBy(option => option.Name))
-            {
-                UninstallRootCommand.AddOption(option);
-            }
-
-            foreach (var option in ListAuxOptions
-                .OrderBy(option => option.Name))
-            {
-                ListCommand.AddOption(option);
-            }
+            AssignOptionsToCommand(ListCommand, ListAuxOptions);
 
             ListCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => ListCommandExec.Execute()));
-            UninstallRootCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => UninstallCommandExec.Execute()));
+            DryRunCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => DryRunCommandExec.Execute()));
+            WhatIfCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => DryRunCommandExec.Execute()));
+            RemoveCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => UninstallCommandExec.Execute()));
 
             CommandLineParseResult = UninstallRootCommand.Parse(Environment.GetCommandLineArgs());
         }
 
         public static Option GetUninstallMainOption(this CommandResult commandResult)
         {
-            var specified = UninstallMainOptions
+            var specified = UninstallFilterBundlesOptions
                 .Where(option => commandResult.OptionResult(option.Name) != null);
 
             if (specified.Count() > 1)
@@ -252,11 +231,11 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             {
                 var optionName = $"--{specifiedOption.Name}";
 
-                if (specifiedOption.Equals(UninstallAllButOption))
+                if (specifiedOption.Name.Equals(UninstallAllButOption.Name))
                 {
                     throw new VersionBeforeOptionException(optionName);
                 }
-                else if (specifiedOption.Equals(UninstallAllBelowOption) || specifiedOption.Equals(UninstallMajorMinorOption))
+                else if (specifiedOption.Name.Equals(UninstallAllBelowOption.Name) || specifiedOption.Name.Equals(UninstallMajorMinorOption.Name))
                 {
                     throw new MoreThanOneVersionSpecifiedException(optionName);
                 }
@@ -317,6 +296,23 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             else
             {
                 throw new VerbosityLevelInvalidException();
+            }
+        }
+
+        private static void AssignOptionsToCommand(Command command, IEnumerable<Option> options, bool addVersionArgument = false)
+        {
+            foreach (var option in options
+                .OrderBy(option => option.Name))
+            {
+                command.AddOption(option);
+            }
+            if (addVersionArgument)
+            {
+                command.AddArgument(new Argument<IEnumerable<string>>
+                {
+                    Name = LocalizableStrings.UninstallNoOptionArgumentName,
+                    Description = LocalizableStrings.UninstallNoOptionArgumentDescription
+                });
             }
         }
     }

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -19,7 +19,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
         private static readonly string RemoveCommandName = "remove";
 
         public static readonly RootCommand UninstallRootCommand = new RootCommand(
-            LocalizableStrings.UninstallNoOptionDescription);
+            RuntimeInfo.RunningOnWindows ? LocalizableStrings.UninstallNoOptionDescriptionWindows 
+            : LocalizableStrings.UninstallNoOptionDescriptionMac);
 
         public static readonly Command ListCommand = new Command(
             ListCommandName,
@@ -120,7 +121,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
         public static readonly Option ForceOption = new Option(
             "--force",
-            LocalizableStrings.ForceOptionDescription);
+            RuntimeInfo.RunningOnWindows ? LocalizableStrings.ForceOptionDescriptionWindows
+            : LocalizableStrings.ForceOptionDescriptionMac);
 
         public static readonly Option[] UninstallFilterBundlesOptions = new Option[]
         {
@@ -159,7 +161,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
         public static readonly Option[] AdditionalUninstallOptions = new Option[]
         {
             VerbosityOption,
-            VersionOption
+            VersionOption, 
+            ForceOption
         };
 
         public static readonly Dictionary<string, VerbosityLevel> VerbosityLevels = new Dictionary<string, VerbosityLevel> 
@@ -191,8 +194,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             RemoveAuxOptions = UninstallBundleTypeOptions
                 .Where(option => supportedBundleTypeNames.Contains(option.Name))
                 .Concat(AdditionalUninstallOptions)
-                .Append(YesOption)
-                .Append(ForceOption);
+                .Append(YesOption);
             if (RuntimeInfo.RunningOnWindows)
             {
                 RemoveAuxOptions = RemoveAuxOptions.Concat(ArchUninstallOptions);

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -7,6 +7,7 @@ using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Commands;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Configs.Verbosity;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 {
@@ -28,10 +29,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             DryRunCommandName,
             LocalizableStrings.DryRunCommandDescription);
 
-        public static readonly Command WhatIfCommand = new Command(
-            WhatIfCommandName,
-            LocalizableStrings.DryRunCommandDescription);
-
         public static readonly Command RemoveCommand = new Command(
            RemoveCommandName,
             LocalizableStrings.RemoveCommandDescription);
@@ -44,19 +41,19 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
         public static readonly string X64OptionName = "x64";
         public static readonly string X86OptionName = "x86";
 
-        public static Option UninstallAllOption => new Option(
+        public static readonly Option UninstallAllOption = new Option(
             "--all",
             LocalizableStrings.UninstallAllOptionDescription);
 
-        public static Option UninstallAllLowerPatchesOption => new Option(
+        public static readonly Option UninstallAllLowerPatchesOption = new Option(
             "--all-lower-patches",
             LocalizableStrings.UninstallAllLowerPatchesOptionDescription);
 
-        public static Option UninstallAllButLatestOption => new Option(
+        public static readonly Option UninstallAllButLatestOption = new Option(
             "--all-but-latest",
             LocalizableStrings.UninstallAllButLatestOptionDescription);
 
-        public static Option UninstallAllButOption => new Option(
+        public static readonly Option UninstallAllButOption = new Option(
             "--all-but",
             LocalizableStrings.UninstallAllButOptionDescription)
         {
@@ -66,7 +63,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             }
         };
 
-        public static Option UninstallAllBelowOption => new Option(
+        public static readonly Option UninstallAllBelowOption = new Option(
             "--all-below",
             LocalizableStrings.UninstallAllBelowOptionDescription)
         {
@@ -76,15 +73,15 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             }
         };
 
-        public static Option UninstallAllPreviewsOption => new Option(
+        public static readonly Option UninstallAllPreviewsOption = new Option(
             "--all-previews",
             LocalizableStrings.UninstallAllPreviewsOptionDescription);
 
-        public static Option UninstallAllPreviewsButLatestOption => new Option(
+        public static readonly Option UninstallAllPreviewsButLatestOption = new Option(
             "--all-previews-but-latest",
             LocalizableStrings.UninstallAllPreviewsButLatestOptionDescription);
 
-        public static Option UninstallMajorMinorOption => new Option(
+        public static readonly Option UninstallMajorMinorOption = new Option(
             "--major-minor",
             LocalizableStrings.UninstallMajorMinorOptionDescription)
         {
@@ -94,7 +91,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             }
         };
 
-        public static Option VerbosityOption => new Option(
+        public static readonly Option VerbosityOption = new Option(
             new[] { "--verbosity", "-v" },
             LocalizableStrings.VerbosityOptionDescription)
         {
@@ -104,24 +101,24 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             }
         };
 
-        public static Option ListX64Option => new Option(
+        public static readonly Option ListX64Option = new Option(
             $"--{X64OptionName}",
             LocalizableStrings.ListX64OptionDescription);
 
-        public static Option ListX86Option => new Option(
+        public static readonly Option ListX86Option = new Option(
             $"--{X86OptionName}",
             LocalizableStrings.ListX86OptionDescription);
 
-        public static Option VersionOption => new Option("--version")
+        public static readonly Option VersionOption = new Option("--version")
         {
             IsHidden = true
         };
 
-        public static Option YesOption => new Option(
+        public static readonly Option YesOption = new Option(
             new[] { "--yes", "-y" },
             LocalizableStrings.YesOptionDescription);
 
-        public static Option[] UninstallFilterBundlesOptions => new Option[]
+        public static readonly Option[] UninstallFilterBundlesOptions = new Option[]
         {
             UninstallAllOption,
             UninstallAllLowerPatchesOption,
@@ -133,7 +130,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             UninstallMajorMinorOption
         };
 
-        public static Option[] ListBundleTypeOptions => new Option[]
+        public static readonly Option[] ListBundleTypeOptions = new Option[]
         {
             new Option($"--{SdkOptionName}", LocalizableStrings.ListSdkOptionDescription),
             new Option($"--{RuntimeOptionName}", LocalizableStrings.ListRuntimeOptionDescription),
@@ -141,7 +138,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             new Option($"--{HostingBundleOptionName}", LocalizableStrings.ListHostingBundleOptionDescription)
         };
 
-        public static Option[] UninstallBundleTypeOptions => new Option[]
+        public static readonly Option[] UninstallBundleTypeOptions = new Option[]
         {
             new Option($"--{SdkOptionName}", LocalizableStrings.UninstallSdkOptionDescription),
             new Option($"--{RuntimeOptionName}", LocalizableStrings.UninstallRuntimeOptionDescription),
@@ -149,10 +146,14 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             new Option($"--{HostingBundleOptionName}", LocalizableStrings.UninstallHostingBundleOptionDescription)
         };
 
-        public static Option[] AdditionalUninstallOptions => new Option[]
+        public static readonly Option[] ArchUninstallOptions = new Option[]
         {
             new Option($"--{X64OptionName}", LocalizableStrings.UninstallX64OptionDescription),
-            new Option($"--{X86OptionName}", LocalizableStrings.UninstallX86OptionDescription),
+            new Option($"--{X86OptionName}", LocalizableStrings.UninstallX86OptionDescription)
+        };
+
+        public static readonly Option[] AdditionalUninstallOptions = new Option[]
+        {
             VerbosityOption,
             VersionOption
         };
@@ -174,9 +175,11 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
         static CommandLineConfigs() 
         {
+            UninstallRootCommand.AddOption(new Option("--version", LocalizableStrings.VersionOptionDescription));
+            DryRunCommand.AddAlias(WhatIfCommandName);
+
             UninstallRootCommand.AddCommand(ListCommand);
             UninstallRootCommand.AddCommand(DryRunCommand);
-            UninstallRootCommand.AddCommand(WhatIfCommand);
             UninstallRootCommand.AddCommand(RemoveCommand);
 
             var supportedBundleTypeNames = SupportedBundleTypeConfigs.GetSupportedBundleTypes().Select(type => type.OptionName);
@@ -185,19 +188,21 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
                 .Where(option => supportedBundleTypeNames.Contains(option.Name))
                 .Concat(AdditionalUninstallOptions)
                 .Append(YesOption);
+            if (RuntimeInfo.RunningOnWindows)
+            {
+                RemoveAuxOptions = RemoveAuxOptions.Concat(ArchUninstallOptions);
+            }
             AssignOptionsToCommand(RemoveCommand, RemoveAuxOptions
                 .Concat(UninstallFilterBundlesOptions), true);
 
             DryRunAuxOptions = UninstallBundleTypeOptions
                 .Where(option => supportedBundleTypeNames.Contains(option.Name))
                 .Concat(AdditionalUninstallOptions);
+            if (RuntimeInfo.RunningOnWindows)
+            {
+                DryRunAuxOptions = DryRunAuxOptions.Concat(ArchUninstallOptions);
+            }
             AssignOptionsToCommand(DryRunCommand, DryRunAuxOptions
-                .Concat(UninstallFilterBundlesOptions), true);
-
-            WhatIfAuxOptions = UninstallBundleTypeOptions
-                .Where(option => supportedBundleTypeNames.Contains(option.Name))
-                .Concat(AdditionalUninstallOptions);
-            AssignOptionsToCommand(WhatIfCommand, WhatIfAuxOptions
                 .Concat(UninstallFilterBundlesOptions), true);
 
             ListAuxOptions = ListBundleTypeOptions
@@ -209,7 +214,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
             ListCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => ListCommandExec.Execute()));
             DryRunCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => DryRunCommandExec.Execute()));
-            WhatIfCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => DryRunCommandExec.Execute()));
             RemoveCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => UninstallCommandExec.Execute()));
 
             CommandLineParseResult = UninstallRootCommand.Parse(Environment.GetCommandLineArgs());
@@ -297,6 +301,12 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             {
                 throw new VerbosityLevelInvalidException();
             }
+        }
+
+        public static bool IsVerbosityLevelAboveNormal()
+        {
+            return CommandLineConfigs.CommandLineParseResult.CommandResult.GetVerbosityLevel().Equals(VerbosityLevel.Detailed)
+                || CommandLineConfigs.CommandLineParseResult.CommandResult.GetVerbosityLevel().Equals(VerbosityLevel.Diagnostic);
         }
 
         private static void AssignOptionsToCommand(Command command, IEnumerable<Option> options, bool addVersionArgument = false)

--- a/src/dotnet-core-uninstall/Shared/Configs/OptionFilterers.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/OptionFilterers.cs
@@ -1,43 +1,44 @@
 ﻿using System.Collections.Generic;
+using System.CommandLine;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Filterers;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 {
     internal static class OptionFilterers
     {
-        public static readonly IDictionary<string, Filterer> OptionFiltererDictionary
-            = new Dictionary<string, Filterer>
+        public static readonly IDictionary<Option, Filterer> OptionFiltererDictionary
+            = new Dictionary<Option, Filterer>
             {
                 {
-                    CommandLineConfigs.UninstallAllOption.Name,
+                    CommandLineConfigs.UninstallAllOption,
                     new AllOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllLowerPatchesOption.Name,
+                    CommandLineConfigs.UninstallAllLowerPatchesOption,
                     new AllLowerPatchesOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllButLatestOption.Name,
+                    CommandLineConfigs.UninstallAllButLatestOption,
                     new AllButLatestOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllButOption.Name,
+                    CommandLineConfigs.UninstallAllButOption,
                     new AllButOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllBelowOption.Name,
+                    CommandLineConfigs.UninstallAllBelowOption,
                     new AllBelowOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllPreviewsOption.Name,
+                    CommandLineConfigs.UninstallAllPreviewsOption,
                     new AllPreviewsOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllPreviewsButLatestOption.Name,
+                    CommandLineConfigs.UninstallAllPreviewsButLatestOption,
                     new AllPreviewsButLatestOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallMajorMinorOption.Name,
+                    CommandLineConfigs.UninstallMajorMinorOption,
                     new MajorMinorOptionFilterer()
                 }
             };

--- a/src/dotnet-core-uninstall/Shared/Configs/OptionFilterers.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/OptionFilterers.cs
@@ -1,44 +1,43 @@
 ﻿using System.Collections.Generic;
-using System.CommandLine;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Filterers;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 {
     internal static class OptionFilterers
     {
-        public static readonly IDictionary<Option, Filterer> OptionFiltererDictionary
-            = new Dictionary<Option, Filterer>
+        public static readonly IDictionary<string, Filterer> OptionFiltererDictionary
+            = new Dictionary<string, Filterer>
             {
                 {
-                    CommandLineConfigs.UninstallAllOption,
+                    CommandLineConfigs.UninstallAllOption.Name,
                     new AllOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllLowerPatchesOption,
+                    CommandLineConfigs.UninstallAllLowerPatchesOption.Name,
                     new AllLowerPatchesOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllButLatestOption,
+                    CommandLineConfigs.UninstallAllButLatestOption.Name,
                     new AllButLatestOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllButOption,
+                    CommandLineConfigs.UninstallAllButOption.Name,
                     new AllButOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllBelowOption,
+                    CommandLineConfigs.UninstallAllBelowOption.Name,
                     new AllBelowOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllPreviewsOption,
+                    CommandLineConfigs.UninstallAllPreviewsOption.Name,
                     new AllPreviewsOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallAllPreviewsButLatestOption,
+                    CommandLineConfigs.UninstallAllPreviewsButLatestOption.Name,
                     new AllPreviewsButLatestOptionFilterer()
                 },
                 {
-                    CommandLineConfigs.UninstallMajorMinorOption,
+                    CommandLineConfigs.UninstallMajorMinorOption.Name,
                     new MajorMinorOptionFilterer()
                 }
             };

--- a/src/dotnet-core-uninstall/Shared/Exceptions/UninstallationNotAllowedException.cs
+++ b/src/dotnet-core-uninstall/Shared/Exceptions/UninstallationNotAllowedException.cs
@@ -1,0 +1,11 @@
+﻿using Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning;
+
+namespace Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions
+{
+    internal class UninstallationNotAllowedException : DotNetUninstallException
+    {
+        public UninstallationNotAllowedException() :
+            base(string.Format(LocalizableStrings.UninstallNotAllowedExceptionFormat, VisualStudioSafeVersionsExtractor.UpperLimit.ToNormalizedString()))
+        { }
+    }
+}

--- a/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
+++ b/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
-using Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions;
 using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
@@ -17,7 +16,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
         private static readonly SemanticVersion[] SpecialCaseDivisions = { new SemanticVersion(2, 1, 600), new SemanticVersion(2, 2, 200) };
 
         // The tool should not be used to uninstall any more recent versions of the sdk
-        private static readonly SemanticVersion UpperLimit = new SemanticVersion(3, 0, 0);
+        public static readonly SemanticVersion UpperLimit = new SemanticVersion(3, 0, 0);
 
         public static IEnumerable<Bundle> GetUninstallableBundles(IEnumerable<Bundle> bundles)
         {
@@ -54,7 +53,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
                 new List<IEnumerable<Bundle>> { bundleList };
         }
 
-        public static Dictionary<Bundle, string> GetListCommandUninstallableStrings(IEnumerable<Bundle> allBundles)
+        public static Dictionary<Bundle, string> GetReasonRequiredStrings(IEnumerable<Bundle> allBundles)
         {
             var uninstallable = GetUninstallableBundles(allBundles);
             var required = allBundles.Where(b => !uninstallable.Contains(b));
@@ -63,16 +62,16 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
                         .ToDictionary(i => i.Key, i => i.Value);
             if (required.Where(b => b.Version.SemVer < SpecialCaseDivisions[0]).Count() > 0) 
             {
-                ListCommandStringResults.Add(required.Where(b => b.Version.SemVer < SpecialCaseDivisions[0]).Max(), "[Required by Visual Studio 2017]");
+                ListCommandStringResults.Add(required.Where(b => b.Version.SemVer < SpecialCaseDivisions[0]).Max(), "Required by Visual Studio 2017");
             }
             foreach (var recentSdk in required.Where(b => b.Version.SemVer >= UpperLimit))
             {
-                ListCommandStringResults.Add(recentSdk, $"[Cannot uninstall version {UpperLimit} and above]");
+                ListCommandStringResults.Add(recentSdk, $"Cannot uninstall version {UpperLimit} and above");
             }
 
             return ListCommandStringResults.Concat(required
                 .Where(b => !ListCommandStringResults.Keys.Contains(b))
-                .Select(b => new KeyValuePair<Bundle, string>(b, $"[Required for {b.Version.Major}.{b.Version.Minor} Applications]")))
+                .Select(b => new KeyValuePair<Bundle, string>(b, $"Required for {b.Version.Major}.{b.Version.Minor} Applications")))
                 .OrderByDescending(pair => pair.Key)
                 .ToDictionary(i => i.Key, i => i.Value);
         }

--- a/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
+++ b/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
@@ -8,76 +7,88 @@ using NuGet.Versioning;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
 {
-    // Visual Studio versions 15.3 thru 15.9 (inclusive) requires an sdk with max version 2.1.5xx (inclusive)
-    //                        16.0 requires anything less than 3.0.1xx
-    // Must keep one of each Major.Minor band to ensure runtime works
     internal static class VisualStudioSafeVersionsExtractor
     {
-        // Divisions within version bands. Not inclusive, groupings: [2.1.000, 2.1.600) [2.1.600, 2.2.00) [2.0.00, 2.2.200) [2.2.200, 2.3.00)
-        private static readonly SemanticVersion[] SpecialCaseDivisions = { new SemanticVersion(2, 1, 600), new SemanticVersion(2, 2, 200) };
-
         // The tool should not be used to uninstall any more recent versions of the sdk
-        public static readonly SemanticVersion UpperLimit = RuntimeInfo.RunningOnWindows ? new SemanticVersion(3, 0, 0) : new SemanticVersion(5, 0, 0);
+        public static readonly SemanticVersion UpperLimit = new SemanticVersion(5, 0, 0);
+
+        // Must keep one of each of these divisions to ensure Visual Studio works. 
+        // Pairs are [inclusive, exclusive)
+        private static readonly Dictionary<(SemanticVersion, SemanticVersion), string> VersionDivisionsToExplaination = new Dictionary<(SemanticVersion, SemanticVersion), string>
+        {
+            { (new SemanticVersion(1, 0, 0), new SemanticVersion(2, 0, 0)),  string.Format(LocalizableStrings.RequirementExplainationString, "") },
+            { (new SemanticVersion(2, 0, 0), new SemanticVersion(2, 1, 300)), string.Format(LocalizableStrings.RequirementExplainationString, "") },
+            { (new SemanticVersion(2, 1, 300), new SemanticVersion(2, 1, 600)), string.Format(LocalizableStrings.RequirementExplainationString, " 2017") },
+            { (new SemanticVersion(2, 1, 600), new SemanticVersion(2, 1, 900)), string.Format(LocalizableStrings.RequirementExplainationString, " 2019") },
+            { (new SemanticVersion(2, 2, 100), new SemanticVersion(2, 2, 200)), string.Format(LocalizableStrings.RequirementExplainationString, " 2017") },
+            { (new SemanticVersion(2, 2, 200), new SemanticVersion(2, 2, 500)), string.Format(LocalizableStrings.RequirementExplainationString, " 2019") },
+            { (new SemanticVersion(2, 2, 500), UpperLimit), string.Format(LocalizableStrings.RequirementExplainationString, "") }
+        };
+
+        private static (IDictionary<IEnumerable<Bundle>, string>, IEnumerable<Bundle>) ApplyVersionDivisions(IEnumerable<Bundle> bundleList)
+        {
+            var dividedBundles = new Dictionary<IEnumerable<Bundle>, string>();
+            foreach (var (division, explaination) in VersionDivisionsToExplaination)
+            {
+                var bundlesInRange = bundleList.Where(bundle => bundle.Version is SdkVersion && division.Item1 <= bundle.Version.SemVer && bundle.Version.SemVer < division.Item2);
+                bundleList = bundleList.Except(bundlesInRange);
+                if (bundlesInRange.Count() > 0)
+                {
+                    dividedBundles.Add(bundlesInRange, explaination);
+                }
+            }
+
+            return (dividedBundles, bundleList);
+        }
 
         public static IEnumerable<Bundle> GetUninstallableBundles(IEnumerable<Bundle> bundles)
         {
-            var required = bundles.Where(b => b.Version.SemVer >= UpperLimit).ToList();
-            var bundlesByBand = SortSdkBundlesByVersionBand(bundles
-                .Where(b => b.Version is SdkVersion)
-                .Select(b => b as Bundle<SdkVersion>));
+            if (!RuntimeInfo.RunningOnWindows) // TODO this will be changed when mac protection is added
+            {
+                return bundles;
+            }
 
-            foreach (IEnumerable<Bundle> band in bundlesByBand)
+            var required = new List<Bundle>();
+            var (bundlesByDivisions, remainingBundles) = ApplyVersionDivisions(bundles);
+
+            foreach (IEnumerable<Bundle> band in bundlesByDivisions.Keys)
             {
                 required.Add(band.Max());
             }
 
+            required = required.Concat(remainingBundles.Where(bundle => bundle.Version.SemVer >= UpperLimit)).ToList();
+
             return bundles.Where(b => !required.Contains(b));
         }
 
-        private static IEnumerable<IEnumerable<Bundle>> SortSdkBundlesByVersionBand(IEnumerable<Bundle<SdkVersion>> bundles)
+        public static Dictionary<Bundle, string> GetReasonRequiredStrings(IEnumerable<Bundle> allBundles)
         {
-            var sortedBundles = new List<IEnumerable<Bundle>>() as IEnumerable<IEnumerable<Bundle>>;
-            var majorMinorGroups = bundles.GroupBy(bundle => bundle.Version.MajorMinor);
-            foreach (SemanticVersion specialCase in SpecialCaseDivisions)
+            if (!RuntimeInfo.RunningOnWindows) // TODO this will be changed when mac protection is added
             {
-                sortedBundles = sortedBundles.Concat(
-                    majorMinorGroups.Select(bundleList => DivideSpecialCases(bundleList, specialCase))
-                    .SelectMany(lst => lst));
-            }
-            return sortedBundles;
-        }
-
-        private static IEnumerable<IEnumerable<Bundle>> DivideSpecialCases(IEnumerable<Bundle> bundleList, SemanticVersion division)
-        {
-            return bundleList.FirstOrDefault().Version.MajorMinor.Equals(new MajorMinorVersion(division.Major, division.Minor)) ?
-                bundleList.GroupBy(bundle => bundle.Version.SemVer.Patch < division.Patch) as IEnumerable<IEnumerable<Bundle>> :
-                new List<IEnumerable<Bundle>> { bundleList };
-        }
-
-        public static Dictionary<Bundle, string> GetReasonRequiredStrings(IEnumerable<Bundle> allBundles, bool verbose)
-        {
-            var uninstallable = GetUninstallableBundles(allBundles);
-            var required = allBundles.Where(b => !uninstallable.Contains(b));
-
-            var ListCommandStringResults = uninstallable.Select(b => new KeyValuePair<Bundle, string>(b, string.Empty))
-                        .ToDictionary(i => i.Key, i => i.Value);
-            if (RuntimeInfo.RunningOnWindows && required.Where(b => b.Version.SemVer < SpecialCaseDivisions[0]).Count() > 0) 
-            {
-                ListCommandStringResults.Add(required.Where(b => b.Version.SemVer < SpecialCaseDivisions[0]).Max(),
-                    verbose ? LocalizableStrings.VisualStudioRequirementLong : LocalizableStrings.VisualStudioRequirementShort);
-            }
-            foreach (var recentSdk in required.Where(b => b.Version.SemVer >= UpperLimit))
-            {
-                ListCommandStringResults.Add(recentSdk, string.Format(
-                    verbose ? LocalizableStrings.UpperLimitRequirementLong : LocalizableStrings.UpperLimitRequirementShort,  UpperLimit));
+                return allBundles.Select(bundle => (bundle, string.Empty))
+                    .ToDictionary(i => i.bundle, i => i.Item2);
             }
 
-            return ListCommandStringResults.Concat(required
-                .Where(b => !ListCommandStringResults.Keys.Contains(b))
-                .Select(b => new KeyValuePair<Bundle, string>(b, string.Format(verbose ? LocalizableStrings.MajorMinorRequirementLong :
-                    LocalizableStrings.MajorMinorRequirementShort, b.Version.Major, b.Version.Minor))))
-                .OrderByDescending(pair => pair.Key)
-                .ToDictionary(i => i.Key, i => i.Value);
+            var (bundlesByDivisions, remainingBundles) = ApplyVersionDivisions(allBundles);
+
+            var bundlesAboveUpperLimit = remainingBundles.Where(bundle => bundle.Version.SemVer >= UpperLimit);
+            var requirementStringResults = remainingBundles.Except(bundlesAboveUpperLimit)
+                .Select(bundle => (bundle, string.Empty))
+                .Concat(bundlesAboveUpperLimit
+                .Select(bundle => (bundle, string.Format(LocalizableStrings.UpperLimitRequirement, UpperLimit))));
+            
+            foreach (var division in bundlesByDivisions)
+            {
+                var requiredBundle = division.Key.Max();
+                requirementStringResults = requirementStringResults.Append((requiredBundle, division.Value));
+                requirementStringResults = requirementStringResults.Concat(division.Key
+                    .Where(bundle => !bundle.Equals(requiredBundle))
+                    .Select(bundle => (bundle, string.Empty)));
+            }
+
+            return requirementStringResults
+                .OrderByDescending(pair => pair.bundle)
+                .ToDictionary(i => i.bundle, i => i.Item2);
         }
     }
 }

--- a/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
+++ b/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
@@ -43,7 +43,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
 
         public static IEnumerable<Bundle> GetUninstallableBundles(IEnumerable<Bundle> bundles)
         {
-            if (!RuntimeInfo.RunningOnWindows) // TODO this will be changed when mac protection is added
+            if (!RuntimeInfo.RunningOnWindows)
             {
                 return bundles;
             }
@@ -63,7 +63,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
 
         public static Dictionary<Bundle, string> GetReasonRequiredStrings(IEnumerable<Bundle> allBundles)
         {
-            if (!RuntimeInfo.RunningOnWindows) // TODO this will be changed when mac protection is added
+            if (!RuntimeInfo.RunningOnWindows)
             {
                 return allBundles.Select(bundle => (bundle, string.Empty))
                     .ToDictionary(i => i.bundle, i => i.Item2);

--- a/src/dotnet-core-uninstall/Windows/RegistryQuery.cs
+++ b/src/dotnet-core-uninstall/Windows/RegistryQuery.cs
@@ -49,7 +49,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Windows
         {
             return IsDotNetCoreBundleDisplayName(registryKey.GetValue("DisplayName") as string)
                 && IsDotNetCoreBundlePublisher(registryKey.GetValue("Publisher") as string)
-                && IsDotNetCoreBundleUninstaller(registryKey.GetValue("WindowsInstaller") as int?);
+                && IsDotNetCoreBundleUninstaller(registryKey.GetValue("WindowsInstaller") as int?)
+                && IsNotVisualStudioDummyVersion(registryKey.GetValue("DisplayName") as string);
+        }
+
+        private static bool IsNotVisualStudioDummyVersion(string displayName)
+        {
+            return !displayName.Contains(" from Visual Studio");
         }
 
         private static bool IsDotNetCoreBundleDisplayName(string displayName)

--- a/src/dotnet-core-uninstall/Windows/SupportedBundleTypeConfigs.cs
+++ b/src/dotnet-core-uninstall/Windows/SupportedBundleTypeConfigs.cs
@@ -23,7 +23,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Windows
                 gridView.SetChild(new ContentView(bundle.Key.Version.ToStringWithAsterisk()), 1, index);
                 gridView.SetChild(new ContentView(bundle.Key.Arch.ToString().ToLower()), 2, index);
                 gridView.SetChild(new ContentView($"\"{bundle.Key.DisplayName}\""), 3, index);
-                gridView.SetChild(new ContentView(bundle.Value), 4, index);
+                gridView.SetChild(new ContentView(bundle.Value.Equals(string.Empty) ? string.Empty : $"[{bundle.Value}]"), 4, index);
             }
 
             return gridView;
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Windows
                 gridView.SetChild(new ContentView(string.Empty), 0, index);
                 gridView.SetChild(new ContentView(bundle.Key.Version.ToStringWithAsterisk()), 1, index);
                 gridView.SetChild(new ContentView($"\"{bundle.Key.DisplayName}\""), 2, index);
-                gridView.SetChild(new ContentView(bundle.Value), 3, index);
+                gridView.SetChild(new ContentView(bundle.Value.Equals(string.Empty) ? string.Empty : $"[{bundle.Value}]"), 3, index);
             }
 
             return gridView;

--- a/src/dotnet-core-uninstall/Windows/SupportedBundleTypeConfigs.cs
+++ b/src/dotnet-core-uninstall/Windows/SupportedBundleTypeConfigs.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Windows
 {
     internal static class SupportedBundleTypeConfigs
     {
-        private static readonly Func<IDictionary<Bundle, string>, GridView> _gridViewGeneratorWithArch = bundles =>
+        private static readonly Func<IDictionary<Bundle, string>, bool, GridView> _gridViewGeneratorWithArch = (bundles, verbose) =>
         {
             var gridView = new GridView();
 
@@ -22,14 +22,14 @@ namespace Microsoft.DotNet.Tools.Uninstall.Windows
                 gridView.SetChild(new ContentView(string.Empty), 0, index);
                 gridView.SetChild(new ContentView(bundle.Key.Version.ToStringWithAsterisk()), 1, index);
                 gridView.SetChild(new ContentView(bundle.Key.Arch.ToString().ToLower()), 2, index);
-                gridView.SetChild(new ContentView($"\"{bundle.Key.DisplayName}\""), 3, index);
+                gridView.SetChild(new ContentView(verbose ? $"\"{bundle.Key.DisplayName}\"" : string.Empty), 3, index);
                 gridView.SetChild(new ContentView(bundle.Value.Equals(string.Empty) ? string.Empty : $"[{bundle.Value}]"), 4, index);
             }
 
             return gridView;
         };
 
-        private static readonly Func<IDictionary<Bundle, string>, GridView> _gridViewGeneratorWithoutArch = bundles =>
+        private static readonly Func<IDictionary<Bundle, string>, bool, GridView> _gridViewGeneratorWithoutArch = (bundles, verbose) =>
         {
             var gridView = new GridView();
 
@@ -40,7 +40,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Windows
             {
                 gridView.SetChild(new ContentView(string.Empty), 0, index);
                 gridView.SetChild(new ContentView(bundle.Key.Version.ToStringWithAsterisk()), 1, index);
-                gridView.SetChild(new ContentView($"\"{bundle.Key.DisplayName}\""), 2, index);
+                gridView.SetChild(new ContentView(verbose ? $"\"{bundle.Key.DisplayName}\"" : string.Empty), 2, index);
                 gridView.SetChild(new ContentView(bundle.Value.Equals(string.Empty) ? string.Empty : $"[{bundle.Value}]"), 3, index);
             }
 

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -56,9 +56,14 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ForceOptionDescription">
-        <source>Execute the command including unreccommended unisntallations.</source>
-        <target state="new">Execute the command including unreccommended unisntallations.</target>
+      <trans-unit id="ForceOptionDescriptionMac">
+        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ForceOptionDescriptionWindows">
+        <source>Force removal of versions that might be used by Visual Studio.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -89,6 +94,15 @@ Run as administrator and use the remove command to uninstall these items.</targe
       <trans-unit id="ListCommandHostingBundleHeader">
         <source>.NET Core Runtime &amp; Hosting Bundles:</source>
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="ListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
@@ -193,8 +207,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -268,8 +282,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentDescription">
-        <source>The specified version to uninstall. You may list several versions, and response files are supported.</source>
-        <target state="new">The specified version to uninstall. You may list several versions, and response files are supported.</target>
+        <source>The specified version to uninstall. You may list several versions. Response files are supported.</source>
+        <target state="new">The specified version to uninstall. You may list several versions. Response files are supported.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionArgumentName">
@@ -277,9 +291,14 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">VERSION</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallNoOptionDescription">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using .NET Core SDK or Runtime installers. Read the documentation of this tool at https://aka.ms/dotnet-core-uninstall.</target>
+      <trans-unit id="UninstallNoOptionDescriptionMac">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNoOptionDescriptionWindows">
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -348,8 +367,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="VersionOptionDescription">
-        <source>Display .NET Core Uninstall Tool Version Information.</source>
-        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <source>Display .NET Core Uninstall Tool version information.</source>
+        <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -56,6 +56,11 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
+      <trans-unit id="ForceOptionDescription">
+        <source>Execute the command including unreccommended unisntallations.</source>
+        <target state="new">Execute the command including unreccommended unisntallations.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>
@@ -126,16 +131,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
-      <trans-unit id="MajorMinorRequirementLong">
-        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
-        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="MajorMinorRequirementShort">
-        <source>Required for {0}.{1} Applications</source>
-        <target state="new">Required for {0}.{1} Applications</target>
-        <note />
-      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -197,6 +192,11 @@ Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="RequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -228,8 +228,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that have been superceded by higher patches.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
@@ -238,13 +238,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes that are marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes that are marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -322,12 +322,7 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
-      <trans-unit id="UpperLimitRequirementLong">
-        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
-        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UpperLimitRequirementShort">
+      <trans-unit id="UpperLimitRequirement">
         <source>Cannot uninstall version {0} and above</source>
         <target state="new">Cannot uninstall version {0} and above</target>
         <note />
@@ -355,16 +350,6 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool Version Information.</source>
         <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementLong">
-        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
-        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="VisualStudioRequirementShort">
-        <source>Required by Visual Studio 2017</source>
-        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</source>
+Run as administrator and use the remove command to remove these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run this command as administrator, and take out the -—dry-run option to remove these items.</target>
+Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -161,6 +161,32 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</target>
+        <note />
+      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -249,6 +275,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="UninstallNormalVerbosityFormat">
         <source>Uninstalling: {0}.</source>
         <target state="new">Uninstalling: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallNotAllowedExceptionFormat">
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -32,7 +32,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 Do you want to continue? [Y/n] </target>
         <note />
       </trans-unit>
-      <trans-unit id="DryRunOptionDescription">
+      <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
         <note />
@@ -101,11 +101,6 @@ Run this command as administrator, and take out the -—dry-run option to remove
         <target state="new">List .NET Core Runtime &amp; Hosting Bundles.</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListIncludeRequiredOptionDescription">
-        <source>Include .NET Core SDKs that cannot be uninstalled.</source>
-        <target state="new">Include .NET Core SDKs that cannot be uninstalled.</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
         <source>List .NET Core Runtimes.</source>
         <target state="new">List .NET Core Runtimes.</target>
@@ -154,6 +149,11 @@ Run this command as administrator, and take out the -—dry-run option to remove
       <trans-unit id="OptionsConflictExceptionMessageFormat">
         <source>You must specify only one of the options: {0}.</source>
         <target state="new">You must specify only one of the options: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="RemoveCommandDescription">
+        <source>Remove the specified .NET Core SDKs or Runtimes.</source>
+        <target state="new">Remove the specified .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
       <trans-unit id="RequiredArgMissingForUninstallCommandExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -45,7 +45,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</source>
+Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -53,7 +53,7 @@ Specified versions:
 
 To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
 
-Run as administrator and use the remove command to remove these items.</target>
+Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
@@ -102,13 +102,13 @@ Run as administrator and use the remove command to remove these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListRuntimeOptionDescription">
-        <source>List .NET Core Runtimes.</source>
-        <target state="new">List .NET Core Runtimes.</target>
+        <source>List .NET Core Runtimes that can be uninstalled.</source>
+        <target state="new">List .NET Core Runtimes that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListSdkOptionDescription">
-        <source>List .NET Core SDKs.</source>
-        <target state="new">List .NET Core SDKs.</target>
+        <source>List .NET Core SDKs that can be uninstalled.</source>
+        <target state="new">List .NET Core SDKs that can be uninstalled.</target>
         <note />
       </trans-unit>
       <trans-unit id="ListX64OptionDescription">
@@ -124,6 +124,16 @@ Run as administrator and use the remove command to remove these items.</target>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementLong">
+        <source>Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</source>
+        <target state="new">Required for {0}.{1} Applications, you will not be able to run these applications without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MajorMinorRequirementShort">
+        <source>Required for {0}.{1} Applications</source>
+        <target state="new">Required for {0}.{1} Applications</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
@@ -312,6 +322,16 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">The uninstallation operation failed. Exit code was {1} for "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="UpperLimitRequirementLong">
+        <source>Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</source>
+        <target state="new">Cannot uninstall version {0} and above, SDK versions handled properly by Visual Studio</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UpperLimitRequirementShort">
+        <source>Cannot uninstall version {0} and above</source>
+        <target state="new">Cannot uninstall version {0} and above</target>
+        <note />
+      </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">
         <source>Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</source>
         <target state="new">Allowed verbosity levels are q[uiet], m[inimal], n[ormal], d[etailed], and diag[nostic].</target>
@@ -330,6 +350,21 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionBeforeOptionExceptionMessageFormat">
         <source>Do not use a version before an option: {0}.</source>
         <target state="new">Do not use a version before an option: {0}.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VersionOptionDescription">
+        <source>Display .NET Core Uninstall Tool Version Information.</source>
+        <target state="new">Display .NET Core Uninstall Tool Version Information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementLong">
+        <source>Required by Visual Studio 2017, Visual Studio will break without this SDK</source>
+        <target state="new">Required by Visual Studio 2017, Visual Studio will break without this SDK</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="VisualStudioRequirementShort">
+        <source>Required by Visual Studio 2017</source>
+        <target state="new">Required by Visual Studio 2017</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+using FluentAssertions;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
+using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Commands;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Configs;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions;
+using Xunit;
+
+namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
+{
+    public class CommandBundleFilterTests
+    {
+        private static readonly string[] versions = { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1", "10.10.10" };
+
+        [Theory]
+        [InlineData("remove --all --sdk", new string[] { "1.0.0", "2.1.0"})]
+        [InlineData("dry-run --all --sdk", new string[] { "1.0.0", "2.1.0" })]
+        [InlineData("whatif --all --sdk", new string[] { "1.0.0", "2.1.0" })]
+        [InlineData("remove --sdk 1.0.1", new string[] { "1.0.1" })]
+        [InlineData("remove --sdk 1.0.0", new string[] { "1.0.0" })]
+        [InlineData("remove --sdk 1.0.1 2.1.0 1.0.1", new string[] { "2.1.0", "1.0.1", "1.0.1" })]
+        [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200", 
+            new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200" })]
+        internal void TestRequiredUninstallableWhenExplicitlyAdded(string command, string[] expectedUninstallable)
+        {
+            var bundles = new List<Bundle<SdkVersion>>();
+            foreach (string v in versions)
+            {
+                bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
+            }
+
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
+            var uninstallableBundles = CommandBundleFilter.GetFilteredBundles(bundles, parseResult)
+                .Select(b => b.DisplayName);
+            var requiredBundles = versions.Where(v => !uninstallableBundles.Contains(v));
+
+            (uninstallableBundles.Count() + requiredBundles.Count()).Should().Be(versions.Length);
+            uninstallableBundles.ToHashSet().Should().BeEquivalentTo(expectedUninstallable.ToHashSet());
+            requiredBundles.Should().BeEquivalentTo(versions.Where(v => !expectedUninstallable.Contains(v)));
+        }
+
+        [Theory]
+        [InlineData("remove --sdk 3.0.0")]
+        [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 3.0.0 3.0.1 10.10.10")]
+        internal void TestUpperLimitAlwaysRequired(string command)
+        {
+            var bundles = new List<Bundle<SdkVersion>>();
+            foreach (string v in versions)
+            {
+                bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
+            }
+
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
+            Action filteringAction = () => CommandBundleFilter.GetFilteredBundles(bundles, parseResult);
+            filteringAction.Should().Throw<UninstallationNotAllowedException>();
+        }
+    }
+}

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -8,6 +8,8 @@ using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Commands;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Configs;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
+using Microsoft.DotNet.Tools.Uninstall.Tests.Attributes;
 using Xunit;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
@@ -16,7 +18,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
     {
         private static readonly string[] versions = { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1", "10.10.10" };
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData("remove --all --sdk", new string[] { "1.0.0", "2.1.0"})]
         [InlineData("dry-run --all --sdk", new string[] { "1.0.0", "2.1.0" })]
         [InlineData("whatif --all --sdk", new string[] { "1.0.0", "2.1.0" })]
@@ -25,6 +27,25 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
         [InlineData("remove --sdk 1.0.1 2.1.0 1.0.1", new string[] { "2.1.0", "1.0.1", "1.0.1" })]
         [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200", 
             new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200" })]
+        internal void TestRequiredUninstallableWhenExplicitlyAddedWindows(string command, string[] expectedUninstallable)
+        {
+            TestRequiredUninstallableWhenExplicitlyAdded(command, expectedUninstallable);
+        }
+
+        [MacOsOnlyTheory]
+        [InlineData("remove --all --sdk", new string[] { "1.0.0", "2.1.0", "3.0.0" })]
+        [InlineData("dry-run --all --sdk", new string[] { "1.0.0", "2.1.0", "3.0.0" })]
+        [InlineData("whatif --all --sdk", new string[] { "1.0.0", "2.1.0", "3.0.0" })]
+        [InlineData("remove --sdk 1.0.1", new string[] { "1.0.1" })]
+        [InlineData("remove --sdk 1.0.0", new string[] { "1.0.0" })]
+        [InlineData("remove --sdk 1.0.1 2.1.0 1.0.1", new string[] { "2.1.0", "1.0.1", "1.0.1" })]
+        [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 3.0.0",
+            new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0" })]
+        internal void TestRequiredUninstallableWhenExplicitlyAddedMac(string command, string[] expectedUninstallable)
+        {
+            TestRequiredUninstallableWhenExplicitlyAdded(command, expectedUninstallable);
+        }
+
         internal void TestRequiredUninstallableWhenExplicitlyAdded(string command, string[] expectedUninstallable)
         {
             var bundles = new List<Bundle<SdkVersion>>();
@@ -43,9 +64,22 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
             requiredBundles.Should().BeEquivalentTo(versions.Where(v => !expectedUninstallable.Contains(v)));
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData("remove --sdk 3.0.0")]
         [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 3.0.0 3.0.1 10.10.10")]
+        internal void TestUpperLimitAlwaysRequiredWindows(string command)
+        {
+            TestUpperLimitAlwaysRequired(command);
+        }
+
+        [MacOsOnlyTheory]
+        [InlineData("remove --sdk 5.0.0")]
+        [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 5.0.0 5.0.1 10.10.10")]
+        internal void TestUpperLimitAlwaysRequiredMac(string command)
+        {
+            TestUpperLimitAlwaysRequired(command);
+        }
+
         internal void TestUpperLimitAlwaysRequired(string command)
         {
             var bundles = new List<Bundle<SdkVersion>>();

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -8,7 +8,6 @@ using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Commands;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Configs;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions;
-using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
 using Microsoft.DotNet.Tools.Uninstall.Tests.Attributes;
 using Xunit;
 
@@ -19,9 +18,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
         private static readonly string[] versions = { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1", "10.10.10" };
 
         [WindowsOnlyTheory]
-        [InlineData("remove --all --sdk", new string[] { "1.0.0", "2.1.0"})]
-        [InlineData("dry-run --all --sdk", new string[] { "1.0.0", "2.1.0" })]
-        [InlineData("whatif --all --sdk", new string[] { "1.0.0", "2.1.0" })]
+        [InlineData("remove --all --sdk", new string[] { "1.0.0", "1.0.1", "3.0.0"})]
+        [InlineData("dry-run --all --sdk", new string[] { "1.0.0", "1.0.1", "3.0.0" })]
+        [InlineData("whatif --all --sdk", new string[] { "1.0.0", "1.0.1", "3.0.0" })]
+        [InlineData("remove --all-below 5.0.0 --sdk --force", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
         [InlineData("remove --sdk 1.0.1", new string[] { "1.0.1" })]
         [InlineData("remove --sdk 1.0.0", new string[] { "1.0.0" })]
         [InlineData("remove --sdk 1.0.1 2.1.0 1.0.1", new string[] { "2.1.0", "1.0.1", "1.0.1" })]
@@ -33,14 +33,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
         }
 
         [MacOsOnlyTheory]
-        [InlineData("remove --all --sdk", new string[] { "1.0.0", "2.1.0", "3.0.0" })]
-        [InlineData("dry-run --all --sdk", new string[] { "1.0.0", "2.1.0", "3.0.0" })]
-        [InlineData("whatif --all --sdk", new string[] { "1.0.0", "2.1.0", "3.0.0" })]
-        [InlineData("remove --sdk 1.0.1", new string[] { "1.0.1" })]
-        [InlineData("remove --sdk 1.0.0", new string[] { "1.0.0" })]
-        [InlineData("remove --sdk 1.0.1 2.1.0 1.0.1", new string[] { "2.1.0", "1.0.1", "1.0.1" })]
-        [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 3.0.0",
-            new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0" })]
+        [InlineData("remove --all --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })] 
+        [InlineData("dry-run --all --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
+        [InlineData("whatif --all --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
         internal void TestRequiredUninstallableWhenExplicitlyAddedMac(string command, string[] expectedUninstallable)
         {
             TestRequiredUninstallableWhenExplicitlyAdded(command, expectedUninstallable);
@@ -65,22 +60,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
         }
 
         [WindowsOnlyTheory]
-        [InlineData("remove --sdk 3.0.0")]
+        [InlineData("remove --sdk 10.10.10")]
+        [InlineData("remove --sdk --all --force")]
         [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 3.0.0 3.0.1 10.10.10")]
         internal void TestUpperLimitAlwaysRequiredWindows(string command)
-        {
-            TestUpperLimitAlwaysRequired(command);
-        }
-
-        [MacOsOnlyTheory]
-        [InlineData("remove --sdk 5.0.0")]
-        [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 5.0.0 5.0.1 10.10.10")]
-        internal void TestUpperLimitAlwaysRequiredMac(string command)
-        {
-            TestUpperLimitAlwaysRequired(command);
-        }
-
-        internal void TestUpperLimitAlwaysRequired(string command)
         {
             var bundles = new List<Bundle<SdkVersion>>();
             foreach (string v in versions)

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -33,9 +33,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
         }
 
         [MacOsOnlyTheory]
-        [InlineData("remove --all --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })] 
-        [InlineData("dry-run --all --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
-        [InlineData("whatif --all --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
+        [InlineData("remove --all-below 5.0.0 --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })] 
+        [InlineData("dry-run --all-below 5.0.0 --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
+        [InlineData("whatif --all-below 5.0.0 --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
         internal void TestRequiredUninstallableWhenExplicitlyAddedMac(string command, string[] expectedUninstallable)
         {
             TestRequiredUninstallableWhenExplicitlyAdded(command, expectedUninstallable);

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
         [InlineData("remove --all --sdk", new string[] { "1.0.0", "1.0.1", "3.0.0"})]
         [InlineData("dry-run --all --sdk", new string[] { "1.0.0", "1.0.1", "3.0.0" })]
         [InlineData("whatif --all --sdk", new string[] { "1.0.0", "1.0.1", "3.0.0" })]
+        [InlineData("whatif --all-below 5.0.0 --sdk --force", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
         [InlineData("remove --all-below 5.0.0 --sdk --force", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
         [InlineData("remove --sdk 1.0.1", new string[] { "1.0.1" })]
         [InlineData("remove --sdk 1.0.0", new string[] { "1.0.0" })]

--- a/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
 {
-    public class CommandLineConfigsTests 
+    public class CommandLineConfigsTests
     {
         [Theory]
         [InlineData("list", new string[] { })]

--- a/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
@@ -198,6 +198,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
 
         [Theory]
         [InlineData("--all --sdk", new string[] { "sdk" })]
+        [InlineData("--all --sdk --force", new string[] { "sdk", "force" })]
         [InlineData("--all-below 2.2.300 --runtime", new string[] { "runtime" })]
         [InlineData("--all-but 2.1.5 2.1.7 3.0.0-preview-10086 --sdk --runtime", new string[] { "sdk", "runtime" })]
         [InlineData("2.1.300 3.0.100-preview-276262-01 --verbosity diagnostic", new string[] { "verbosity" })]

--- a/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
@@ -12,7 +12,7 @@ using Xunit;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
 {
-    public class CommandLineConfigsTests
+    public class CommandLineConfigsTests 
     {
         [Theory]
         [InlineData("list", new string[] { })]
@@ -104,22 +104,90 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("--all-previews")]
         [InlineData("--all-previews-but-latest")]
         [InlineData("--major-minor", "2.2", "2.2")]
+        [InlineData("", "2.2.300", new[] { "2.2.300" })] 
+        [InlineData("", "2.2.300 3.0.100", new[] { "2.2.300", "3.0.100" })]
+        [InlineData("", "--unknown-option", new[] { "--unknown-option" })]
+        [InlineData("", "--unknown-option argument", new[] { "--unknown-option", "argument" })]
+        internal void TestRemoveCommandAccept(string option, string argValue = "", object expected = null)
+        {
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"remove {option} {argValue}");
+
+            if (!option.Equals(string.Empty))
+            {
+                parseResult.CommandResult.OptionResult(option).Should().NotBeNull();
+                parseResult.CommandResult.ValueForOption(option).Should().BeEquivalentTo(expected);
+            }
+            else
+            {
+                parseResult.CommandResult.Tokens.Select(t => t.Value).As<object>()
+                    .Should().BeEquivalentTo(expected);
+            }
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.UnparsedTokens.Should().BeEmpty();
+            parseResult.UnmatchedTokens.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("--all")]
+        [InlineData("--all-lower-patches")]
+        [InlineData("--all-but-latest")]
+        [InlineData("--all-but", "2.2.300", new[] { "2.2.300" })]
+        [InlineData("--all-but", "2.2.300 3.0.100", new[] { "2.2.300", "3.0.100" })]
+        [InlineData("--all-below", "2.2.300", "2.2.300")]
+        [InlineData("--all-previews")]
+        [InlineData("--all-previews-but-latest")]
+        [InlineData("--major-minor", "2.2", "2.2")]
         [InlineData("", "2.2.300", new[] { "2.2.300" })]
         [InlineData("", "2.2.300 3.0.100", new[] { "2.2.300", "3.0.100" })]
         [InlineData("", "--unknown-option", new[] { "--unknown-option" })]
         [InlineData("", "--unknown-option argument", new[] { "--unknown-option", "argument" })]
-        internal void TestOptionsAccept(string option, string argValue = "", object expected = null)
+        internal void TestDryRunCommandAccept(string option, string argValue = "", object expected = null)
         {
-            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"{option} {argValue}");
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"dry-run {option} {argValue}");
 
             if (!option.Equals(string.Empty))
             {
-                parseResult.RootCommandResult.OptionResult(option).Should().NotBeNull();
-                parseResult.RootCommandResult.ValueForOption(option).Should().BeEquivalentTo(expected);
+                parseResult.CommandResult.OptionResult(option).Should().NotBeNull();
+                parseResult.CommandResult.ValueForOption(option).Should().BeEquivalentTo(expected);
             }
             else
             {
-                parseResult.RootCommandResult.Tokens.Select(t => t.Value).As<object>()
+                parseResult.CommandResult.Tokens.Select(t => t.Value).As<object>()
+                    .Should().BeEquivalentTo(expected);
+            }
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.UnparsedTokens.Should().BeEmpty();
+            parseResult.UnmatchedTokens.Should().BeEmpty();
+        }
+
+        [Theory]
+        [InlineData("--all")]
+        [InlineData("--all-lower-patches")]
+        [InlineData("--all-but-latest")]
+        [InlineData("--all-but", "2.2.300", new[] { "2.2.300" })]
+        [InlineData("--all-but", "2.2.300 3.0.100", new[] { "2.2.300", "3.0.100" })]
+        [InlineData("--all-below", "2.2.300", "2.2.300")]
+        [InlineData("--all-previews")]
+        [InlineData("--all-previews-but-latest")]
+        [InlineData("--major-minor", "2.2", "2.2")]
+        [InlineData("", "2.2.300", new[] { "2.2.300" })]
+        [InlineData("", "2.2.300 3.0.100", new[] { "2.2.300", "3.0.100" })]
+        [InlineData("", "--unknown-option", new[] { "--unknown-option" })]
+        [InlineData("", "--unknown-option argument", new[] { "--unknown-option", "argument" })]
+        internal void TestWhatIfCommandAccept(string option, string argValue = "", object expected = null)
+        {
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"whatif {option} {argValue}");
+
+            if (!option.Equals(string.Empty))
+            {
+                parseResult.CommandResult.OptionResult(option).Should().NotBeNull();
+                parseResult.CommandResult.ValueForOption(option).Should().BeEquivalentTo(expected);
+            }
+            else
+            {
+                parseResult.CommandResult.Tokens.Select(t => t.Value).As<object>()
                     .Should().BeEquivalentTo(expected);
             }
 
@@ -136,27 +204,69 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("--all -v quiet --sdk", new string[] { "verbosity", "sdk" })]
         [InlineData("--major-minor 2.3 --verbosity m --runtime", new string[] { "verbosity", "runtime" })]
         [InlineData("--all-but 2.1.5 2.1.7 3.0.0-preview-10086 --sdk -v n --runtime", new string[] { "verbosity", "sdk", "runtime" })]
-        [InlineData("--all --sdk --dry-run", new string[] { "sdk", "dry-run" })]
         [InlineData("--all-below 2.2.300 --runtime --yes", new string[] { "runtime", "yes" })]
         [InlineData("--all-but 2.1.5 2.1.7 3.0.0-preview-10086 --sdk -y --runtime", new string[] { "sdk", "runtime", "yes" })]
-        [InlineData("2.1.300 3.0.100-preview-276262-01 --dry-run --verbosity diagnostic", new string[] { "verbosity", "dry-run" })]
-        internal void TestOptionsAcceptAux(string command, string[] expectedAuxOptions)
+        internal void TestRemoveCommandAcceptAux(string command, string[] expectedAuxOptions)
         {
-            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse("remove " + command);
 
             parseResult.Errors.Should().BeEmpty();
             parseResult.UnparsedTokens.Should().BeEmpty();
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
-            CommandLineConfigs.UninstallAuxOptions
+            CommandLineConfigs.RemoveAuxOptions
+                .Select(option => option.Name)
+                .Where(option => parseResult.CommandResult.OptionResult(option) != null)
+                .Should().BeEquivalentTo(expectedAuxOptions);
+        }
+
+        [Theory]
+        [InlineData("--all --sdk", new string[] { "sdk" })]
+        [InlineData("--all-below 2.2.300 --runtime", new string[] { "runtime" })]
+        [InlineData("--all-but 2.1.5 2.1.7 3.0.0-preview-10086 --sdk --runtime", new string[] { "sdk", "runtime" })]
+        [InlineData("2.1.300 3.0.100-preview-276262-01 --verbosity diagnostic", new string[] { "verbosity" })]
+        [InlineData("--all -v quiet --sdk", new string[] { "verbosity", "sdk" })]
+        [InlineData("--major-minor 2.3 --verbosity m --runtime", new string[] { "verbosity", "runtime" })]
+        [InlineData("--all-but 2.1.5 2.1.7 3.0.0-preview-10086 --sdk -v n --runtime", new string[] { "verbosity", "sdk", "runtime" })]
+        internal void TestDryRunCommandAcceptAux(string command, string[] expectedAuxOptions)
+        {
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse("dry-run " + command);
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.UnparsedTokens.Should().BeEmpty();
+            parseResult.UnmatchedTokens.Should().BeEmpty();
+
+            CommandLineConfigs.RemoveAuxOptions
+                .Select(option => option.Name)
+                .Where(option => parseResult.CommandResult.OptionResult(option) != null)
+                .Should().BeEquivalentTo(expectedAuxOptions);
+        }
+
+        [Theory]
+        [InlineData("--all --sdk", new string[] { "sdk" })]
+        [InlineData("--all-below 2.2.300 --runtime", new string[] { "runtime" })]
+        [InlineData("--all-but 2.1.5 2.1.7 3.0.0-preview-10086 --sdk --runtime", new string[] { "sdk", "runtime" })]
+        [InlineData("2.1.300 3.0.100-preview-276262-01 --verbosity diagnostic", new string[] { "verbosity" })]
+        [InlineData("--all -v quiet --sdk", new string[] { "verbosity", "sdk" })]
+        [InlineData("--major-minor 2.3 --verbosity m --runtime", new string[] { "verbosity", "runtime" })]
+        [InlineData("--all-but 2.1.5 2.1.7 3.0.0-preview-10086 --sdk -v n --runtime", new string[] { "verbosity", "sdk", "runtime" })]
+        internal void TestWhatIfCommandAcceptAux(string command, string[] expectedAuxOptions)
+        {
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse("whatif " + command);
+
+            parseResult.Errors.Should().BeEmpty();
+            parseResult.UnparsedTokens.Should().BeEmpty();
+            parseResult.UnmatchedTokens.Should().BeEmpty();
+
+            CommandLineConfigs.RemoveAuxOptions
                 .Select(option => option.Name)
                 .Where(option => parseResult.CommandResult.OptionResult(option) != null)
                 .Should().BeEquivalentTo(expectedAuxOptions);
         }
 
         [WindowsOnlyTheory]
-        [InlineData("--all --sdk --aspnet-runtime", new string[] { "sdk", "aspnet-runtime" })]
-        [InlineData("--major-minor 1.1 --hosting-bundle -v q", new string[] { "hosting-bundle", "verbosity" })]
+        [InlineData("remove --all --sdk --aspnet-runtime", new string[] { "sdk", "aspnet-runtime" })]
+        [InlineData("remove --major-minor 1.1 --hosting-bundle -v q", new string[] { "hosting-bundle", "verbosity" })]
         internal void TestOptionsAcceptAuxWindows(string command, string[] expectedAuxOptions)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
@@ -165,15 +275,29 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnparsedTokens.Should().BeEmpty();
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
-            CommandLineConfigs.UninstallAuxOptions
+            CommandLineConfigs.RemoveAuxOptions
                 .Select(option => option.Name)
                 .Where(option => parseResult.CommandResult.OptionResult(option) != null)
                 .Should().BeEquivalentTo(expectedAuxOptions);
         }
 
         [Theory]
+        [InlineData("")]
+        internal void TestOptionsReject(string command)
+        {
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
+
+            (parseResult.Errors.Count != 0 ||
+                parseResult.UnparsedTokens.Count != 0 ||
+                parseResult.UnmatchedTokens.Count != 0 ||
+                parseResult.CommandResult.Tokens.Count != 0)
+            .Should().BeTrue();
+        }
+
+        [Theory]
         [InlineData("--all-but")]
         [InlineData("--all-below")]
+        [InlineData("--dry-run")]
         [InlineData("--major-minor")]
         [InlineData("--all-but --sdk")]
         [InlineData("--all-below --runtime")]
@@ -187,25 +311,81 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("--dry-run --all-but")]
         [InlineData("--yes --verbosity")]
         [InlineData("--major-minor -y")]
-        internal void TestOptionsReject(string command)
+        internal void TestRemoveCommandReject(string command)
         {
-            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse("remove " + command);
 
             (parseResult.Errors.Count != 0 ||
                 parseResult.UnparsedTokens.Count != 0 ||
                 parseResult.UnmatchedTokens.Count != 0 ||
-                parseResult.RootCommandResult.Tokens.Count != 0)
+                parseResult.CommandResult.Tokens.Count != 0)
+            .Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("--all-but")]
+        [InlineData("--yes")]
+        [InlineData("--all-below")]
+        [InlineData("--dry-run")]
+        [InlineData("--major-minor")]
+        [InlineData("--all-but --sdk")]
+        [InlineData("--all-below --runtime")]
+        [InlineData("--major-minor --verbosity q --sdk --runtime")]
+        [InlineData("--verbosity")]
+        [InlineData("-v")]
+        [InlineData("--all-but 2.2.300 -v")]
+        [InlineData("--all-below 1.23.456 -v")]
+        [InlineData("--major-minor 3.0 --verbosity")]
+        [InlineData("--all-but 2.1.5 2.1.7 3.0.0 --sdk --verbosity")]
+        [InlineData("--dry-run --all-but")]
+        [InlineData("--yes --verbosity")]
+        internal void TestDryRunCommandReject(string command)
+        {
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse("dry-run " + command);
+
+            (parseResult.Errors.Count != 0 ||
+                parseResult.UnparsedTokens.Count != 0 ||
+                parseResult.UnmatchedTokens.Count != 0 ||
+                parseResult.CommandResult.Tokens.Count != 0)
+            .Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData("--all-but")]
+        [InlineData("--yes")]
+        [InlineData("--all-below")]
+        [InlineData("--dry-run")]
+        [InlineData("--major-minor")]
+        [InlineData("--all-but --sdk")]
+        [InlineData("--all-below --runtime")]
+        [InlineData("--major-minor --verbosity q --sdk --runtime")]
+        [InlineData("--verbosity")]
+        [InlineData("-v")]
+        [InlineData("--all-but 2.2.300 -v")]
+        [InlineData("--all-below 1.23.456 -v")]
+        [InlineData("--major-minor 3.0 --verbosity")]
+        [InlineData("--all-but 2.1.5 2.1.7 3.0.0 --sdk --verbosity")]
+        [InlineData("--dry-run --all-but")]
+        [InlineData("--yes --verbosity")]
+        internal void TestWhatIfCommandReject(string command)
+        {
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse("whatif " + command);
+
+            (parseResult.Errors.Count != 0 ||
+                parseResult.UnparsedTokens.Count != 0 ||
+                parseResult.UnmatchedTokens.Count != 0 ||
+                parseResult.CommandResult.Tokens.Count != 0)
             .Should().BeTrue();
         }
 
         [MacOsOnlyTheory]
-        [InlineData("--all --aspnet-runtime")]
-        [InlineData("--major-minor 1.1 --hosting-bundle")]
-        [InlineData("--all-but 2.2.300 --sdk --aspnet-runtime -v q")]
-        [InlineData("--all-below 2.2 --verbosity normal --sdk --hosting-bundle")]
-        [InlineData("--major-minor 1.1 --hosting-bundle --dry-run")]
-        [InlineData("--all-but 2.2.300 --sdk --aspnet-runtime --yes -v q")]
-        [InlineData("--all-below 2.2 --verbosity normal -y --sdk --hosting-bundle")]
+        [InlineData("remove --all --aspnet-runtime")]
+        [InlineData("remove --major-minor 1.1 --hosting-bundle")]
+        [InlineData("remove --all-but 2.2.300 --sdk --aspnet-runtime -v q")]
+        [InlineData("remove --all-below 2.2 --verbosity normal --sdk --hosting-bundle")]
+        [InlineData("remove --major-minor 1.1 --hosting-bundle --dry-run")]
+        [InlineData("remove --all-but 2.2.300 --sdk --aspnet-runtime --yes -v q")]
+        [InlineData("remove --all-below 2.2 --verbosity normal -y --sdk --hosting-bundle")]
         internal void TestOptionsRejectMacOs(string command)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
@@ -227,224 +407,297 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("--all-previews")]
         [InlineData("--all-previews-but-latest")]
         [InlineData("--major-minor", "2.2")]
+        [InlineData("", "2.2.300")] 
+        [InlineData("", "2.2.300 3.0.100")]
+        [InlineData("", "--unknown-option")]
+        [InlineData("", "--unknown-option argument")]
+        internal void TestGetUninstallRemoveOptionAccept(string option, string argValue = "")
+        {
+            var commandResult = CommandLineConfigs.UninstallRootCommand.Parse($"remove {option} {argValue}").CommandResult;
+
+            if (option.Equals(string.Empty))
+            {
+                commandResult.GetUninstallMainOption().Should().BeNull();
+            } 
+            else
+            {
+                commandResult.GetUninstallMainOption().Name
+                    .Should().Be(commandResult.OptionResult(option).Option.Name);
+            }
+        }
+
+        [Theory]
+        [InlineData("--all")]
+        [InlineData("--all-lower-patches")]
+        [InlineData("--all-but-latest")]
+        [InlineData("--all-but", "2.2.300")]
+        [InlineData("--all-but", "2.2.300 3.0.100")]
+        [InlineData("--all-below", "2.2.300")]
+        [InlineData("--all-previews")]
+        [InlineData("--all-previews-but-latest")]
+        [InlineData("--major-minor", "2.2")]
         [InlineData("", "2.2.300")]
         [InlineData("", "2.2.300 3.0.100")]
         [InlineData("", "--unknown-option")]
         [InlineData("", "--unknown-option argument")]
-        internal void TestGetUninstallMainOptionAccept(string option, string argValue = "")
+        internal void TestGetUninstallDryRunOptionAccept(string option, string argValue = "")
         {
-            var rootCommandResult = CommandLineConfigs.UninstallRootCommand.Parse($"{option} {argValue}").RootCommandResult;
+            var commandResult = CommandLineConfigs.UninstallRootCommand.Parse($"dry-run {option} {argValue}").CommandResult;
 
-            rootCommandResult.GetUninstallMainOption()
-                .Should().Be(option.Equals(string.Empty) ? null : rootCommandResult.OptionResult(option).Option);
+            if (option.Equals(string.Empty))
+            {
+                commandResult.GetUninstallMainOption().Should().BeNull();
+            }
+            else
+            {
+                commandResult.GetUninstallMainOption().Name
+                    .Should().Be(commandResult.OptionResult(option).Option.Name);
+            }
+        }
+
+        [Theory]
+        [InlineData("--all")]
+        [InlineData("--all-lower-patches")]
+        [InlineData("--all-but-latest")]
+        [InlineData("--all-but", "2.2.300")]
+        [InlineData("--all-but", "2.2.300 3.0.100")]
+        [InlineData("--all-below", "2.2.300")]
+        [InlineData("--all-previews")]
+        [InlineData("--all-previews-but-latest")]
+        [InlineData("--major-minor", "2.2")]
+        [InlineData("", "2.2.300")]
+        [InlineData("", "2.2.300 3.0.100")]
+        [InlineData("", "--unknown-option")]
+        [InlineData("", "--unknown-option argument")]
+        internal void TestGetUninstallWhatIfOptionAccept(string option, string argValue = "")
+        {
+            var commandResult = CommandLineConfigs.UninstallRootCommand.Parse($"whatif {option} {argValue}").CommandResult;
+
+            if (option.Equals(string.Empty))
+            {
+                commandResult.GetUninstallMainOption().Should().BeNull();
+            }
+            else
+            {
+                commandResult.GetUninstallMainOption().Name
+                    .Should().Be(commandResult.OptionResult(option).Option.Name);
+            }
         }
 
         public static IEnumerable<object[]> GetDataForTestGetUninstallMainOptionOptionsConflictException()
         {
             yield return new object[]
             {
-                (Option: "--all", ArgValue: ""),
-                (Option: "--all-lower-patches", ArgValue: "")
+                (Command: "remove", Option: "--all", ArgValue: ""),
+                (Command: "remove", Option: "--all-lower-patches", ArgValue: "")
             };
 
             yield return new object[]
             {
-                (Option: "--all", ArgValue: ""),
-                (Option: "--all-below", ArgValue: "2.2.300")
+                (Command: "dry-run", Option: "--all", ArgValue: ""),
+                (Command: "dry-run", Option: "--all-below", ArgValue: "2.2.300")
             };
 
             yield return new object[]
             {
-                (Option: "--all", ArgValue: ""),
-                (Option: "--all-but", ArgValue: "2.2.300 2.1.700")
+                (Command: "whatif", Option: "--all", ArgValue: ""),
+                (Command: "whatif", Option: "--all-but", ArgValue: "2.2.300 2.1.700")
             };
 
             yield return new object[]
             {
-                (Option: "--all-below", ArgValue: "2.1.700"),
-                (Option: "--major-minor", ArgValue: "2.1")
+                (Command: "remove", Option: "--all-below", ArgValue: "2.1.700"),
+                (Command: "remove", Option: "--major-minor", ArgValue: "2.1")
             };
 
             yield return new object[]
             {
-                (Option: "--all-below", ArgValue: "2.1.700"),
-                (Option: "--all-but", ArgValue: "2.2.300 3.0.100")
+                (Command: "remove", Option: "--all-below", ArgValue: "2.1.700"),
+                (Command: "remove", Option: "--all-but", ArgValue: "2.2.300 3.0.100")
             };
 
             yield return new object[]
             {
-                (Option: "--all-below", ArgValue: "2.1.700"),
-                (Option: "--all-but", ArgValue: "2.2.300 3.0.100 --unknown-option")
+                (Command: "remove", Option: "--all-below", ArgValue: "2.1.700"),
+                (Command: "remove", Option: "--all-but", ArgValue: "2.2.300 3.0.100 --unknown-option")
             };
 
             yield return new object[]
             {
-                (Option: "--all-below", ArgValue: "--unknown-option"),
-                (Option: "--all-but", ArgValue: "2.2.300 3.0.100")
+                (Command: "remove", Option: "--all-below", ArgValue: "--unknown-option"),
+                (Command: "remove", Option: "--all-but", ArgValue: "2.2.300 3.0.100")
             };
 
             yield return new object[]
             {
-                (Option: "--all-below", ArgValue: "2.2.300"),
-                (Option: "--major-minor", ArgValue: "--unknown-option")
+                (Command: "remove", Option: "--all-below", ArgValue: "2.2.300"),
+                (Command: "remove", Option: "--major-minor", ArgValue: "--unknown-option")
             };
 
             yield return new object[]
             {
-                (Option: "--all-lower-patches", ArgValue: ""),
-                (Option: "--all", ArgValue: "")
+                (Command: "remove", Option: "--all-lower-patches", ArgValue: ""),
+                (Command: "remove", Option: "--all", ArgValue: "")
             };
 
             yield return new object[]
             {
-                (Option: "--all-below", ArgValue: "2.2.300"),
-                (Option: "--all", ArgValue: "")
+                (Command: "remove", Option: "--all-below", ArgValue: "2.2.300"),
+                (Command: "remove", Option: "--all", ArgValue: "")
             };
 
             yield return new object[]
             {
-                (Option: "--all-but", ArgValue: "2.2.300 2.1.700"),
-                (Option: "--all", ArgValue: "")
+                (Command: "remove", Option: "--all-but", ArgValue: "2.2.300 2.1.700"),
+                (Command: "remove", Option: "--all", ArgValue: "")
             };
 
             yield return new object[]
             {
-                (Option: "--major-minor", ArgValue: "2.1"),
-                (Option: "--all-below", ArgValue: "2.1.700")
+                (Command: "remove", Option: "--major-minor", ArgValue: "2.1"),
+                (Command: "remove", Option: "--all-below", ArgValue: "2.1.700")
             };
 
             yield return new object[]
             {
-                (Option: "--all-but", ArgValue: "2.2.300 3.0.100"),
-                (Option: "--all-below", ArgValue: "2.1.700")
+                (Command: "remove", Option: "--all-but", ArgValue: "2.2.300 3.0.100"),
+                (Command: "remove", Option: "--all-below", ArgValue: "2.1.700")
             };
 
             yield return new object[]
             {
-                (Option: "--all-but", ArgValue: "2.2.300 3.0.100 --unknown-option"),
-                (Option: "--all-below", ArgValue: "2.1.700")
+                (Command: "remove", Option: "--all-but", ArgValue: "2.2.300 3.0.100 --unknown-option"),
+                (Command: "remove", Option: "--all-below", ArgValue: "2.1.700")
             };
 
             yield return new object[]
             {
-                (Option: "--all-but", ArgValue: "2.2.300 3.0.100"),
-                (Option: "--all-below", ArgValue: "--unknown-option")
+                (Command: "remove", Option: "--all-but", ArgValue: "2.2.300 3.0.100"),
+                (Command: "remove", Option: "--all-below", ArgValue: "--unknown-option")
             };
 
             yield return new object[]
             {
-                (Option: "--major-minor", ArgValue: "--unknown-option"),
-                (Option: "--all-below", ArgValue: "2.2.300")
+                (Command: "remove", Option: "--major-minor", ArgValue: "--unknown-option"),
+                (Command: "remove", Option: "--all-below", ArgValue: "2.2.300")
             };
 
             yield return new object[]
             {
-                (Option: "--all", ArgValue: ""),
-                (Option: "--all-lower-patches", ArgValue: ""),
-                (Option: "--all-below", ArgValue: "2.2.300")
+                (Command: "remove", Option: "--all", ArgValue: ""),
+                (Command: "remove", Option: "--all-lower-patches", ArgValue: ""),
+                (Command: "remove", Option: "--all-below", ArgValue: "2.2.300")
             };
 
             yield return new object[]
             {
-                (Option: "--all", ArgValue: ""),
-                (Option: "--all-below", ArgValue: "2.1.700"),
-                (Option: "--all-but", ArgValue: "2.2.300 --unknown-option")
+                (Command: "remove", Option: "--all", ArgValue: ""),
+                (Command: "remove", Option: "--all-below", ArgValue: "2.1.700"),
+                (Command: "remove", Option: "--all-but", ArgValue: "2.2.300 --unknown-option")
             };
 
             yield return new object[]
             {
-                (Option: "--all", ArgValue: ""),
-                (Option: "--all-but", ArgValue: "2.1.700 3.0.100"),
-                (Option: "--all-but", ArgValue: "2.2.300 --unknown-option")
+                (Command: "remove", Option: "--all", ArgValue: ""),
+                (Command: "remove", Option: "--all-but", ArgValue: "2.1.700 3.0.100"),
+                (Command: "remove", Option: "--all-but", ArgValue: "2.2.300 --unknown-option")
             };
 
             yield return new object[]
             {
-                (Option: "--all", ArgValue: ""),
-                (Option: "--all-below", ArgValue: "2.1.700"),
-                (Option: "--all-but", ArgValue: "2.2.300 --unknown-option"),
-                (Option: "--all-lower-patches", ArgValue: ""),
-                (Option: "--major-minor", ArgValue: "2.2"),
-                (Option: "--all-previews-but-latest", ArgValue: "")
+                (Command: "remove", Option: "--all", ArgValue: ""),
+                (Command: "remove", Option: "--all-below", ArgValue: "2.1.700"),
+                (Command: "remove", Option: "--all-but", ArgValue: "2.2.300 --unknown-option"),
+                (Command: "remove", Option: "--all-lower-patches", ArgValue: ""),
+                (Command: "remove", Option: "--major-minor", ArgValue: "2.2"),
+                (Command: "remove", Option: "--all-previews-but-latest", ArgValue: "")
             };
         }
 
         [Theory]
         [MemberData(nameof(GetDataForTestGetUninstallMainOptionOptionsConflictException))]
-        internal void TestGetUninstallMainOptionOptionsConflictException(params (string Option, string ArgValue)[] options)
+        internal void TestGetUninstallMainOptionOptionsConflictException(params (string Command, string Option, string ArgValue)[] options)
         {
-            var command = string.Join(" ", options.Select(option => $"{option.Option} {option.ArgValue}"));
+            var command = string.Join(" ", options.Select(option => $"{option.Command} {option.Option} {option.ArgValue}"));
             var optionNames = string.Join(", ", options.Select(option => $"--{option.Option}"));
 
             Action action = () => CommandLineConfigs.UninstallRootCommand.Parse(command)
-            .RootCommandResult.GetUninstallMainOption();
+                .CommandResult.GetUninstallMainOption();
 
             action.Should().Throw<OptionsConflictException>(string.Format(LocalizableStrings.OptionsConflictExceptionMessageFormat, optionNames));
         }
 
         [Theory]
-        [InlineData("--all", "2.2.300")]
-        [InlineData("--all", "--unknown-option")]
-        internal void TestGetUninstallMainOptionMoreThanZeroVersionSpecifiedException(string option, string commandArgValue)
+        [InlineData("remove", "--all", "2.2.300")]
+        [InlineData("remove", "--all", "--unknown-option")]
+        [InlineData("dry-run", "--all", "2.2.300")]
+        [InlineData("whatif", "--all", "2.2.300")]
+        internal void TestGetUninstallMainOptionMoreThanZeroVersionSpecifiedException(string command, string option, string commandArgValue)
         {
-            Action action1 = () => CommandLineConfigs.UninstallRootCommand.Parse($"{option} {commandArgValue}")
-            .RootCommandResult.GetUninstallMainOption();
+            Action action1 = () => CommandLineConfigs.UninstallRootCommand.Parse($"{command} {option} {commandArgValue}")
+                .CommandResult.GetUninstallMainOption();
 
-            Action action2 = () => CommandLineConfigs.UninstallRootCommand.Parse($"{commandArgValue} {option}")
-            .RootCommandResult.GetUninstallMainOption();
+            Action action2 = () => CommandLineConfigs.UninstallRootCommand.Parse($"{command} {commandArgValue} {option}")
+                .CommandResult.GetUninstallMainOption();
 
             action1.Should().Throw<MoreThanZeroVersionSpecifiedException>(string.Format(LocalizableStrings.MoreThanZeroVersionSpecifiedExceptionMessageFormat, option));
             action2.Should().Throw<MoreThanZeroVersionSpecifiedException>(string.Format(LocalizableStrings.MoreThanZeroVersionSpecifiedExceptionMessageFormat, option));
         }
 
         [Theory]
-        [InlineData("--all-below", "2.1.700", "2.2.300")]
-        [InlineData("--all-below", "--unknown-option-1", "--unknown-option-2")]
-        internal void TestGetUninstallMainOptionMoreThanOneVersionSpecifiedException(string option, string commandArgValue, string optionArgValue)
+        [InlineData("remove", "--all-below", "2.1.700", "2.2.300")]
+        [InlineData("whatif", "--all-below", "2.1.700", "2.2.300")]
+        [InlineData("dry-run", "--all-below", "2.1.700", "2.2.300")]
+        [InlineData("remove", "--all-below", "--unknown-option-1", "--unknown-option-2")]
+        internal void TestGetUninstallMainOptionMoreThanOneVersionSpecifiedException(string command, string option, string commandArgValue, string optionArgValue)
         {
-            Action action1 = () => CommandLineConfigs.UninstallRootCommand.Parse($"{option} {optionArgValue} {commandArgValue}")
-            .RootCommandResult.GetUninstallMainOption();
+            Action action1 = () => CommandLineConfigs.UninstallRootCommand.Parse($"{command} {option} {optionArgValue} {commandArgValue}")
+                .CommandResult.GetUninstallMainOption();
 
-            Action action2 = () => CommandLineConfigs.UninstallRootCommand.Parse($"{commandArgValue} {option} {optionArgValue}")
-            .RootCommandResult.GetUninstallMainOption();
+            Action action2 = () => CommandLineConfigs.UninstallRootCommand.Parse($"{command} {commandArgValue} {option} {optionArgValue}")
+                .CommandResult.GetUninstallMainOption();
 
             action1.Should().Throw<MoreThanOneVersionSpecifiedException>(string.Format(LocalizableStrings.MoreThanOneVersionSpecifiedExceptionMessageFormat, option));
             action2.Should().Throw<MoreThanOneVersionSpecifiedException>(string.Format(LocalizableStrings.MoreThanOneVersionSpecifiedExceptionMessageFormat, option));
         }
 
         [Theory]
-        [InlineData("--all-but", "2.2.300")]
-        [InlineData("--all-but", "2.2.300 2.1.700")]
-        [InlineData("--all-but", "--unknown-option 2.1.700")]
-        [InlineData("--all-but", "2.1.700 --unknown-option")]
-        [InlineData("--all-but", "--unknown-option-1 --unknown-option-2")]
-        [InlineData("--all-but", "2.2.300", "2.1.700")]
-        [InlineData("--all-but", "2.2.300 2.1.700", "2.1.202 2.2.233")]
-        [InlineData("--all-but", "--unknown-option 2.1.700", "--unknown-option-2")]
-        [InlineData("--all-but", "2.1.700 --unknown-option", "--unknown-option-2 2.3.333")]
-        [InlineData("--all-but", "--unknown-option-1 --unknown-option-2", "3.0.100")]
-        internal void TestGetUninstallMainOptionVersionBeforeOptionException(string option, string commandArgValue, string optionArgValue = "")
+        [InlineData("remove", "--all-but", "2.2.300")]
+        [InlineData("whatif", "--all-but", "2.2.300")]
+        [InlineData("dry-run", "--all-but", "2.2.300")]
+        [InlineData("remove", "--all-but", "2.2.300 2.1.700")]
+        [InlineData("remove", "--all-but", "--unknown-option 2.1.700")]
+        [InlineData("remove", "--all-but", "2.1.700 --unknown-option")]
+        [InlineData("remove", "--all-but", "--unknown-option-1 --unknown-option-2")]
+        [InlineData("remove", "--all-but", "2.2.300", "2.1.700")]
+        [InlineData("remove", "--all-but", "2.2.300 2.1.700", "2.1.202 2.2.233")]
+        [InlineData("remove", "--all-but", "--unknown-option 2.1.700", "--unknown-option-2")]
+        [InlineData("remove", "--all-but", "2.1.700 --unknown-option", "--unknown-option-2 2.3.333")]
+        [InlineData("remove", "--all-but", "--unknown-option-1 --unknown-option-2", "3.0.100")]
+        internal void TestGetUninstallMainOptionVersionBeforeOptionException(string command, string option, string commandArgValue, string optionArgValue = "")
         {
-            Action action = () => CommandLineConfigs.UninstallRootCommand.Parse($"{commandArgValue} {option} {optionArgValue}")
-            .RootCommandResult.GetUninstallMainOption();
+            Action action = () => CommandLineConfigs.UninstallRootCommand.Parse($"{command} {commandArgValue} {option} {optionArgValue}")
+                .CommandResult.GetUninstallMainOption();
 
             action.Should().Throw<VersionBeforeOptionException>(string.Format(LocalizableStrings.VersionBeforeOptionExceptionMessageFormat, option));
         }
 
         [Theory]
-        [InlineData("--sdk", BundleType.Sdk)]
-        [InlineData("--runtime", BundleType.Runtime)]
-        [InlineData("--sdk --runtime", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("--sdk --verbosity minimal", BundleType.Sdk)]
-        [InlineData("-v normal --runtime", BundleType.Runtime)]
-        [InlineData("--sdk --verbosity diag --runtime", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("--sdk --all-but 2.2.300 2.1.700", BundleType.Sdk)]
-        [InlineData("--runtime --all-below 3.0.1-preview-10086", BundleType.Runtime)]
-        [InlineData("--sdk --runtime --all-previews", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("--runtime --all --dry-run", BundleType.Runtime)]
-        [InlineData("--yes --sdk --all-below 2.0", BundleType.Sdk)]
-        [InlineData("--sdk --runtime -y", BundleType.Sdk | BundleType.Runtime)]
-        internal void TestGetTypeSelectionRootCommand(string command, BundleType expected)
+        [InlineData("remove --sdk", BundleType.Sdk)]
+        [InlineData("remove --runtime", BundleType.Runtime)]
+        [InlineData("remove --sdk --runtime", BundleType.Sdk | BundleType.Runtime)]
+        [InlineData("remove --sdk --verbosity minimal", BundleType.Sdk)]
+        [InlineData("remove -v normal --runtime", BundleType.Runtime)]
+        [InlineData("remove --sdk --verbosity diag --runtime", BundleType.Sdk | BundleType.Runtime)]
+        [InlineData("remove --sdk --all-but 2.2.300 2.1.700", BundleType.Sdk)]
+        [InlineData("remove --runtime --all-below 3.0.1-preview-10086", BundleType.Runtime)]
+        [InlineData("remove --sdk --runtime --all-previews", BundleType.Sdk | BundleType.Runtime)]
+        [InlineData("remove --runtime --all", BundleType.Runtime)]
+        [InlineData("remove --yes --sdk --all-below 2.0", BundleType.Sdk)]
+        [InlineData("remove --sdk --runtime -y", BundleType.Sdk | BundleType.Runtime)]
+        [InlineData("dry-run --sdk --runtime", BundleType.Sdk | BundleType.Runtime)]
+        [InlineData("whatif --sdk --runtime", BundleType.Sdk | BundleType.Runtime)]
+        internal void TestGetTypeSelectionRemoveCommand(string command, BundleType expected)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
 
@@ -452,22 +705,21 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnparsedTokens.Should().BeEmpty();
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
-            parseResult.RootCommandResult.GetTypeSelection()
+            parseResult.CommandResult.GetTypeSelection()
                 .Should().Be(expected);
         }
 
         [WindowsOnlyTheory]
-        [InlineData("", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
-        [InlineData("-v q", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
-        [InlineData("--all", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
-        [InlineData("--aspnet-runtime", BundleType.AspNetRuntime)]
-        [InlineData("--sdk --aspnet-runtime --all-but 2.2.3", BundleType.Sdk | BundleType.AspNetRuntime)]
-        [InlineData("--sdk --runtime --aspnet-runtime", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime)]
-        [InlineData("--hosting-bundle --aspnet-runtime", BundleType.AspNetRuntime | BundleType.HostingBundle)]
-        [InlineData("--hosting-bundle --sdk --all", BundleType.Sdk | BundleType.HostingBundle)]
-        [InlineData("--dry-run", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
-        [InlineData("--yes", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
-        [InlineData("-y", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
+        [InlineData("remove", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
+        [InlineData("remove -v q", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
+        [InlineData("remove --all", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
+        [InlineData("remove --aspnet-runtime", BundleType.AspNetRuntime)]
+        [InlineData("remove --sdk --aspnet-runtime --all-but 2.2.3", BundleType.Sdk | BundleType.AspNetRuntime)]
+        [InlineData("remove --sdk --runtime --aspnet-runtime", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime)]
+        [InlineData("remove --hosting-bundle --aspnet-runtime", BundleType.AspNetRuntime | BundleType.HostingBundle)]
+        [InlineData("remove --hosting-bundle --sdk --all", BundleType.Sdk | BundleType.HostingBundle)]
+        [InlineData("remove --yes", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
+        [InlineData("remove -y", BundleType.Sdk | BundleType.Runtime | BundleType.AspNetRuntime | BundleType.HostingBundle)]
         internal void TestGetTypeSelectionRootCommandWindows(string command, BundleType expected)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
@@ -476,7 +728,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnparsedTokens.Should().BeEmpty();
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
-            parseResult.RootCommandResult.GetTypeSelection()
+            parseResult.CommandResult.GetTypeSelection()
                 .Should().Be(expected);
         }
 
@@ -484,7 +736,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("", BundleType.Sdk | BundleType.Runtime)]
         [InlineData("-v q", BundleType.Sdk | BundleType.Runtime)]
         [InlineData("--all", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("--dry-run", BundleType.Sdk | BundleType.Runtime)]
         [InlineData("--yes", BundleType.Sdk | BundleType.Runtime)]
         [InlineData("-y", BundleType.Sdk | BundleType.Runtime)]
         internal void TestGetTypeSelectionRootCommandMacOs(string command, BundleType expected)
@@ -495,19 +746,19 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnparsedTokens.Should().BeEmpty();
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
-            parseResult.RootCommandResult.GetTypeSelection()
+            parseResult.CommandResult.GetTypeSelection()
                 .Should().Be(expected);
         }
 
         [Theory]
-        [InlineData("2.2.300 --sdk", VerbosityLevel.Normal)]
-        [InlineData("--all -v q --sdk", VerbosityLevel.Quiet)]
-        [InlineData("--all-below 2.2 --verbosity minimal --sdk", VerbosityLevel.Minimal)]
-        [InlineData("--all-but 2.2.300 2.1.700 -v normal --runtime", VerbosityLevel.Normal)]
-        [InlineData("--runtime --all-previews --verbosity d", VerbosityLevel.Detailed)]
-        [InlineData("-v diag --runtime --major-minor 2.2", VerbosityLevel.Diagnostic)]
-        [InlineData("-v diagnostic --major-minor 2.2 --runtime", VerbosityLevel.Diagnostic)]
-        [InlineData("1.1.11 -v normal --hosting-bundle", VerbosityLevel.Normal)]
+        [InlineData("remove 2.2.300 --sdk", VerbosityLevel.Normal)]
+        [InlineData("remove --all -v q --sdk", VerbosityLevel.Quiet)]
+        [InlineData("remove --all-below 2.2 --verbosity minimal --sdk", VerbosityLevel.Minimal)]
+        [InlineData("remove --all-but 2.2.300 2.1.700 -v normal --runtime", VerbosityLevel.Normal)]
+        [InlineData("remove --runtime --all-previews --verbosity d", VerbosityLevel.Detailed)]
+        [InlineData("remove -v diag --runtime --major-minor 2.2", VerbosityLevel.Diagnostic)]
+        [InlineData("remove -v diagnostic --major-minor 2.2 --runtime", VerbosityLevel.Diagnostic)]
+        [InlineData("remove 1.1.11 -v normal --hosting-bundle", VerbosityLevel.Normal)]
         [InlineData("list", VerbosityLevel.Normal)]
         [InlineData("list -v q", VerbosityLevel.Quiet)]
         [InlineData("list --verbosity minimal", VerbosityLevel.Minimal)]
@@ -515,11 +766,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         [InlineData("list --verbosity d", VerbosityLevel.Detailed)]
         [InlineData("list -v diag", VerbosityLevel.Diagnostic)]
         [InlineData("list -v diagnostic", VerbosityLevel.Diagnostic)]
-        [InlineData("-v q list", VerbosityLevel.Normal)]
         [InlineData("list -v d", VerbosityLevel.Detailed)]
-        [InlineData("--sdk --all --dry-run", VerbosityLevel.Normal)]
-        [InlineData("--runtime --all-below 2.0 --yes -v q", VerbosityLevel.Quiet)]
-        [InlineData("--runtime --all-previews --y -v diag", VerbosityLevel.Diagnostic)]
+        [InlineData("remove --runtime --all-below 2.0 --yes -v q", VerbosityLevel.Quiet)]
+        [InlineData("remove --runtime --all-previews --y -v diag", VerbosityLevel.Diagnostic)]
         internal void TestGetVerbosityLevel(string command, VerbosityLevel expected)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
@@ -533,9 +782,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         }
 
         [Theory]
-        [InlineData("2.2.300 --sdk -v qu")]
-        [InlineData("--all --sdk --verbosity mini")]
-        [InlineData("--major-minor 2.1 -v unknown")]
+        [InlineData("remove 2.2.300 --sdk -v qu")]
+        [InlineData("remove --all --sdk --verbosity mini")]
+        [InlineData("remove --major-minor 2.1 -v unknown")]
         [InlineData("list -v qu")]
         [InlineData("list --verbosity mini")]
         [InlineData("list -v unknown")]
@@ -548,15 +797,14 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         }
 
         [Theory]
-        [InlineData("--version")]
-        [InlineData("--all --sdk --version")]
-        [InlineData("2.2.300 --runtime --version")]
-        [InlineData("--version 2.2.300 --runtime")]
-        [InlineData("--version --major-minor 2.1")]
-        [InlineData("--version --all-but 2.2.300 2.1.700")]
-        [InlineData("--all --sdk --version --dry-run")]
-        [InlineData("2.2.5 --runtime -y --version")]
-        [InlineData("--version --sdk 2.2.300 2.1.700 --yes")]
+        [InlineData("remove --version")]
+        [InlineData("remove --all --sdk --version")]
+        [InlineData("remove 2.2.300 --runtime --version")]
+        [InlineData("remove --version 2.2.300 --runtime")]
+        [InlineData("remove --version --major-minor 2.1")]
+        [InlineData("remove --version --all-but 2.2.300 2.1.700")]
+        [InlineData("remove 2.2.5 --runtime -y --version")]
+        [InlineData("remove --version --sdk 2.2.300 2.1.700 --yes")]
         internal void TestVersionOption(string command)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
@@ -565,7 +813,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             parseResult.UnparsedTokens.Should().BeEmpty();
             parseResult.UnmatchedTokens.Should().BeEmpty();
 
-            parseResult.RootCommandResult.OptionResult(CommandLineConfigs.VersionOption.Name)
+            parseResult.CommandResult.OptionResult(CommandLineConfigs.VersionOption.Name)
                 .Should().NotBeNull();
         }
     }

--- a/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Configs/CommandLineConfigsTests.cs
@@ -393,7 +393,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
             (parseResult.Errors.Count != 0 ||
                 parseResult.UnparsedTokens.Count != 0 ||
                 parseResult.UnmatchedTokens.Count != 0 ||
-                parseResult.RootCommandResult.Tokens.Count != 0)
+                parseResult.CommandResult.Tokens.Count != 0)
             .Should().BeTrue();
         }
 
@@ -733,11 +733,11 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Configs
         }
 
         [MacOsOnlyTheory]
-        [InlineData("", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("-v q", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("--all", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("--yes", BundleType.Sdk | BundleType.Runtime)]
-        [InlineData("-y", BundleType.Sdk | BundleType.Runtime)]
+        [InlineData("remove", BundleType.Sdk | BundleType.Runtime)]
+        [InlineData("remove -v q", BundleType.Sdk | BundleType.Runtime)]
+        [InlineData("remove --all", BundleType.Sdk | BundleType.Runtime)]
+        [InlineData("remove --yes", BundleType.Sdk | BundleType.Runtime)]
+        [InlineData("remove -y", BundleType.Sdk | BundleType.Runtime)]
         internal void TestGetTypeSelectionRootCommandMacOs(string command, BundleType expected)
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);

--- a/test/dotnet-core-uninstall.Tests/Shared/Filterers/FiltererTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Filterers/FiltererTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal abstract Option Option { get; }
         internal abstract string DefaultTestArgValue { get; }
-        internal virtual Filterer OptionFilterer => OptionFilterers.OptionFiltererDictionary[Option.Name];
+        internal virtual Filterer OptionFilterer => OptionFilterers.OptionFiltererDictionary[Option];
 
         internal const BundleArch DefaultTestArchSelection = BundleArch.X86 | BundleArch.X64;
 

--- a/test/dotnet-core-uninstall.Tests/Shared/Filterers/FiltererTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Filterers/FiltererTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
     {
         internal abstract Option Option { get; }
         internal abstract string DefaultTestArgValue { get; }
-        internal virtual Filterer OptionFilterer => OptionFilterers.OptionFiltererDictionary[Option];
+        internal virtual Filterer OptionFilterer => OptionFilterers.OptionFiltererDictionary[Option.Name];
 
         internal const BundleArch DefaultTestArchSelection = BundleArch.X86 | BundleArch.X64;
 
@@ -142,7 +142,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
 
         internal virtual void TestFiltererGood(IEnumerable<Bundle> testBundles, string argValue, IEnumerable<Bundle> expected, BundleType typeSelection, BundleArch archSelection)
         {
-            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"--{Option.Name} {argValue}");
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"dry-run --{Option.Name} {argValue}");
 
             OptionFilterer.Filter(parseResult, Option, testBundles, typeSelection, archSelection)
                 .Should().BeEquivalentTo(expected);
@@ -151,7 +151,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         internal virtual void TestFiltererException<TException>(IEnumerable<Bundle> testBundles, string argValue, BundleType typeSelection, BundleArch archSelection)
             where TException : Exception
         {
-            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"--{Option.Name} {argValue}");
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"dry-run --{Option.Name} {argValue}");
             Action action = () => OptionFilterer.Filter(parseResult, Option, testBundles, typeSelection, archSelection);
 
             action.Should().Throw<TException>();
@@ -160,7 +160,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         internal virtual void TestFiltererException<TException>(IEnumerable<Bundle> testBundles, string argValue, BundleType typeSelection, BundleArch archSelection, string errorMessage)
             where TException : Exception
         {
-            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"--{Option.Name} {argValue}");
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"dry-run --{Option.Name} {argValue}");
             Action action = () => OptionFilterer.Filter(parseResult, Option, testBundles, typeSelection, archSelection);
 
             action.Should().Throw<TException>(errorMessage);

--- a/test/dotnet-core-uninstall.Tests/Shared/Filterers/NoOptionFiltererTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Filterers/NoOptionFiltererTests.cs
@@ -234,10 +234,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
 
         internal override void TestFiltererGood(IEnumerable<Bundle> testBundles, string argValue, IEnumerable<Bundle> expected, BundleType typeSelection, BundleArch archSelection)
         {
-            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"{argValue}");
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"remove {argValue}");
 
             (OptionFilterer as ArgFilterer<IEnumerable<string>>).Filter(
-                parseResult.RootCommandResult.Tokens.Select(t => t.Value),
+                parseResult.CommandResult.Tokens.Select(t => t.Value),
                 testBundles,
                 typeSelection,
                 archSelection)
@@ -248,7 +248,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"{argValue}");
             Action action = () => (OptionFilterer as ArgFilterer<IEnumerable<string>>).Filter(
-                parseResult.RootCommandResult.Tokens.Select(t => t.Value),
+                parseResult.CommandResult.Tokens.Select(t => t.Value),
                 testBundles,
                 typeSelection,
                 archSelection);
@@ -258,9 +258,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Filterers
 
         internal override void TestFiltererException<TException>(IEnumerable<Bundle> testBundles, string argValue, BundleType typeSelection, BundleArch archSelection, string errorMessage)
         {
-            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"{argValue}");
+            var parseResult = CommandLineConfigs.UninstallRootCommand.Parse($"remove {argValue}");
             Action action = () => (OptionFilterer as ArgFilterer<IEnumerable<string>>).Filter(
-                parseResult.RootCommandResult.Tokens.Select(t => t.Value),
+                parseResult.CommandResult.Tokens.Select(t => t.Value),
                 testBundles,
                 typeSelection,
                 archSelection);

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -85,7 +85,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [Theory]
         [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "", "Required by Visual Studio 2017" })]
         [InlineData(new string[] { "2.3.0", "2.2.0", "2.1.0" }, new string[] { "Required for 2.3 Applications", "Required for 2.2 Applications", "Required by Visual Studio 2017" })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new string[] { "", "Required for 1.0 Applications", "[Required by Visual Studio 2017" })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new string[] { "", "Required for 1.0 Applications", "Required by Visual Studio 2017" })]
         [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new string[] { "Required by Visual Studio 2017", "", "Required for 2.1 Applications" })]
         [InlineData(new string[] { "2.1.500", "3.0.1", "3.0.0" }, new string[] { "Required by Visual Studio 2017", "Cannot uninstall version 3.0.0 and above", "Cannot uninstall version 3.0.0 and above" })]
         internal void TestGetListCommandUninstallableStrings(string[] versions, string[] expectedStrings)

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -83,11 +83,11 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         }
 
         [Theory]
-        [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "", "[Required by Visual Studio 2017]" })]
-        [InlineData(new string[] { "2.3.0", "2.2.0", "2.1.0" }, new string[] { "[Required for 2.3 Applications]", "[Required for 2.2 Applications]", "[Required by Visual Studio 2017]" })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new string[] { "", "[Required for 1.0 Applications]", "[Required by Visual Studio 2017]" })]
-        [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new string[] { "[Required by Visual Studio 2017]", "", "[Required for 2.1 Applications]" })]
-        [InlineData(new string[] { "2.1.500", "3.0.1", "3.0.0" }, new string[] { "[Required by Visual Studio 2017]", "[Cannot uninstall version 3.0.0 and above]", "[Cannot uninstall version 3.0.0 and above]" })]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "", "Required by Visual Studio 2017" })]
+        [InlineData(new string[] { "2.3.0", "2.2.0", "2.1.0" }, new string[] { "Required for 2.3 Applications", "Required for 2.2 Applications", "Required by Visual Studio 2017" })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new string[] { "", "Required for 1.0 Applications", "[Required by Visual Studio 2017" })]
+        [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new string[] { "Required by Visual Studio 2017", "", "Required for 2.1 Applications" })]
+        [InlineData(new string[] { "2.1.500", "3.0.1", "3.0.0" }, new string[] { "Required by Visual Studio 2017", "Cannot uninstall version 3.0.0 and above", "Cannot uninstall version 3.0.0 and above" })]
         internal void TestGetListCommandUninstallableStrings(string[] versions, string[] expectedStrings)
         {
             var bundles = new List<Bundle>
@@ -101,7 +101,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
                 bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
             }
 
-            var strings = VisualStudioSafeVersionsExtractor.GetListCommandUninstallableStrings(bundles);
+            var strings = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(bundles);
 
             strings.Count().Should().Be(bundles.Count());
             strings.Where(pair => !(pair.Key.Version is SdkVersion)).Select(pair => pair.Value).ToList().ForEach(str => str.Should().Be(string.Empty));

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -131,7 +131,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "3.1.500", "5.0.1", "5.0.0" }, new string[] { "None", "None", "None" })]
         internal void TestGetListCommandUninstallableStringsMac(string[] versions, string[] expectedStrings)
         {
-            TestGetListCommandUninstallableStrings(versions, expectedStrings);
+            TestGetListCommandUninstallableStrings(versions, ConvertStringInput(expectedStrings));
         }
 
         internal void TestGetListCommandUninstallableStrings(string[] versions, string[] expectedStrings)

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -11,7 +11,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
 {
     public class VSVersionTests
     {
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData(new string[] { "1.0.0" }, new bool[] { false })]
         [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
         [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, false })]
@@ -23,6 +23,28 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "2.2.100", "2.2.200" }, new bool[] { false, false })]
         [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "3.0.0", "3.0.1", "10.100.100" }, new bool[] { false, false, false })]
+        internal void TestGetUninstallableWindows(string[] versions, bool[] allowed)
+        {
+            TestGetUninstallable(versions, allowed);
+        }
+
+        [MacOsOnlyTheory]
+        [InlineData(new string[] { "1.0.0" }, new bool[] { false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
+        [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "2.0.0" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "1.0.2" }, new bool[] { true, true, false })]
+        [InlineData(new string[] { "2.1.500", "2.1.600" }, new bool[] { false, false })]
+        [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new bool[] { false, true, false })]
+        [InlineData(new string[] { "2.2.100", "2.2.200" }, new bool[] { false, false })]
+        [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
+        [InlineData(new string[] { "3.0.0", "3.0.1", "10.100.100" }, new bool[] { true, false, false })]
+        internal void TestGetUninstallableMac(string[] versions, bool[] allowed)
+        {
+            TestGetUninstallable(versions, allowed);
+        }
+
         internal void TestGetUninstallable(string[] versions, bool[] allowed)
         {
             var bundles = new List<Bundle<SdkVersion>>();
@@ -36,7 +58,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
             CheckAllowed(bundles, uninstallable, allowed);
         }
 
-        [Theory]
+        [WindowsOnlyTheory]
         [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
         [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, false, false })]
         [InlineData(new string[] { "1.0.0", "1.0.1", "2.0.0" }, new bool[] { true, false, false })]
@@ -44,6 +66,24 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "3.0.0", "3.0.1", "10.100.100" }, new bool[] { false, false, false })]
+        internal void TestGetUninstallableNonSdkVersionsWindows(string[] versions, bool[] allowed)
+        {
+            TestGetUninstallableNonSdkVersions(versions, allowed);
+        }
+
+        [MacOsOnlyTheory]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "2.0.0" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "1.0.2" }, new bool[] { true, true, false })]
+        [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new bool[] { false, true, false })]
+        [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
+        [InlineData(new string[] { "3.0.0", "3.0.1", "10.100.100" }, new bool[] { true, false, false })]
+        internal void TestGetUninstallableNonSdkVersionsMac(string[] versions, bool[] allowed)
+        {
+            TestGetUninstallableNonSdkVersions(versions, allowed);
+        }
+
         internal void TestGetUninstallableNonSdkVersions(string[] versions, bool[] allowed)
         {
             var bundles = new List<Bundle>
@@ -90,34 +130,21 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new string[] { "", "Required for 1.0 Applications", "Required by Visual Studio 2017" })]
         [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new string[] { "Required by Visual Studio 2017", "", "Required for 2.1 Applications" })]
         [InlineData(new string[] { "2.1.500", "3.0.1", "3.0.0" }, new string[] { "Required by Visual Studio 2017", "Cannot uninstall version 3.0.0 and above", "Cannot uninstall version 3.0.0 and above" })]
-        internal void TestGetListCommandUninstallableStrings(string[] versions, string[] expectedStrings)
+        internal void TestGetListCommandUninstallableStringsWindows(string[] versions, string[] expectedStrings)
         {
-            var bundles = new List<Bundle>
-            {
-                new Bundle<RuntimeVersion>(new RuntimeVersion(), new BundleArch(), string.Empty, "RuntimeVersion"),
-                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion(), new BundleArch(), string.Empty, "AspNetVersion"),
-                new Bundle<HostingBundleVersion>(new HostingBundleVersion(), new BundleArch(), string.Empty, "HostingBundleVersion")
-            };
-            foreach (string v in versions)
-            {
-                bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
-            }
-
-            var strings = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(bundles, false);
-
-            strings.Count().Should().Be(bundles.Count());
-            strings.Where(pair => !(pair.Key.Version is SdkVersion)).Select(pair => pair.Value).ToList().ForEach(str => str.Should().Be(string.Empty));
-            for (int i = 0; i < versions.Length; i++)
-            {
-                strings.First(pair => pair.Key.DisplayName.Equals(versions[i])).Value.Should().Be(expectedStrings[i]);
-            }
+            TestGetListCommandUninstallableStrings(versions, expectedStrings);
         }
 
         [MacOsOnlyTheory]
         [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "", "Required for 1.0 Applications" })]
         [InlineData(new string[] { "2.3.0", "2.2.0" }, new string[] { "Required for 2.3 Applications", "Required for 2.2 Applications" })]
-        [InlineData(new string[] { "2.1.500", "3.0.1", "3.0.0" }, new string[] { "Required for 2.1 Applications", "Cannot uninstall version 3.0.0 and above", "Cannot uninstall version 3.0.0 and above" })]
+        [InlineData(new string[] { "3.1.500", "5.0.1", "5.0.0" }, new string[] { "Required for 3.1 Applications", "Cannot uninstall version 5.0.0 and above", "Cannot uninstall version 5.0.0 and above" })]
         internal void TestGetListCommandUninstallableStringsMac(string[] versions, string[] expectedStrings)
+        {
+            TestGetListCommandUninstallableStrings(versions, expectedStrings);
+        }
+
+        internal void TestGetListCommandUninstallableStrings(string[] versions, string[] expectedStrings)
         {
             var bundles = new List<Bundle>
             {

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -5,6 +5,7 @@ using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
 using Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning;
 using Microsoft.DotNet.Tools.Uninstall.Tests.Attributes;
+using NuGet.Versioning;
 using Xunit;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
@@ -15,31 +16,26 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "1.0.0" }, new bool[] { false })]
         [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
         [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, false })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, true, false })]
         [InlineData(new string[] { "1.0.0", "1.0.1", "2.0.0" }, new bool[] { true, false, false })]
         [InlineData(new string[] { "1.0.0", "1.0.1", "1.0.2" }, new bool[] { true, true, false })]
         [InlineData(new string[] { "2.1.500", "2.1.600" }, new bool[] { false, false })]
         [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "2.2.100", "2.2.200" }, new bool[] { false, false })]
         [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
-        [InlineData(new string[] { "3.0.0", "3.0.1", "10.100.100" }, new bool[] { false, false, false })]
+        [InlineData(new string[] { "3.0.0", "3.0.1", "5.0.0" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableWindows(string[] versions, bool[] allowed)
         {
             TestGetUninstallable(versions, allowed);
         }
 
+        // TODO For now we are not protecting versions on mac
         [MacOsOnlyTheory]
-        [InlineData(new string[] { "1.0.0" }, new bool[] { false })]
-        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
-        [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, false })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, false, false })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "2.0.0" }, new bool[] { true, false, false })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "1.0.2" }, new bool[] { true, true, false })]
-        [InlineData(new string[] { "2.1.500", "2.1.600" }, new bool[] { false, false })]
-        [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new bool[] { false, true, false })]
-        [InlineData(new string[] { "2.2.100", "2.2.200" }, new bool[] { false, false })]
-        [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
-        [InlineData(new string[] { "3.0.0", "3.0.1", "10.100.100" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "1.0.0" }, new bool[] { true })]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, true })]
+        [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { true, true })]
+        [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { true, true, true })]
         internal void TestGetUninstallableMac(string[] versions, bool[] allowed)
         {
             TestGetUninstallable(versions, allowed);
@@ -60,25 +56,21 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
 
         [WindowsOnlyTheory]
         [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, true, false })]
         [InlineData(new string[] { "1.0.0", "1.0.1", "2.0.0" }, new bool[] { true, false, false })]
         [InlineData(new string[] { "1.0.0", "1.0.1", "1.0.2" }, new bool[] { true, true, false })]
         [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
-        [InlineData(new string[] { "3.0.0", "3.0.1", "10.100.100" }, new bool[] { false, false, false })]
+        [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableNonSdkVersionsWindows(string[] versions, bool[] allowed)
         {
             TestGetUninstallableNonSdkVersions(versions, allowed);
         }
 
         [MacOsOnlyTheory]
-        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, false, false })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "2.0.0" }, new bool[] { true, false, false })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "1.0.2" }, new bool[] { true, true, false })]
-        [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new bool[] { false, true, false })]
-        [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
-        [InlineData(new string[] { "3.0.0", "3.0.1", "10.100.100" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, true })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, true, true })]
+        [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { true, true, true })]
         internal void TestGetUninstallableNonSdkVersionsMac(string[] versions, bool[] allowed)
         {
             TestGetUninstallableNonSdkVersions(versions, allowed);
@@ -123,22 +115,20 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
             }
         }
 
-        
         [WindowsOnlyTheory]
-        [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "", "Required by Visual Studio 2017" })]
-        [InlineData(new string[] { "2.3.0", "2.2.0", "2.1.0" }, new string[] { "Required for 2.3 Applications", "Required for 2.2 Applications", "Required by Visual Studio 2017" })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new string[] { "", "Required for 1.0 Applications", "Required by Visual Studio 2017" })]
-        [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new string[] { "Required by Visual Studio 2017", "", "Required for 2.1 Applications" })]
-        [InlineData(new string[] { "2.1.500", "3.0.1", "3.0.0" }, new string[] { "Required by Visual Studio 2017", "Cannot uninstall version 3.0.0 and above", "Cannot uninstall version 3.0.0 and above" })]
+        [InlineData(new string[] { "1.0.1", "1.0.0" }, new string[] { "", "None" })]
+        [InlineData(new string[] { "2.3.0", "2.1.800", "2.1.300" }, new string[] { "", " 2019", " 2017" })]
+        [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new string[] { " 2017", "None", " 2019" })]
+        [InlineData(new string[] { "2.1.500", "5.0.1", "5.0.0" }, new string[] { " 2017", "5.0.0", "5.0.0" })]
         internal void TestGetListCommandUninstallableStringsWindows(string[] versions, string[] expectedStrings)
         {
-            TestGetListCommandUninstallableStrings(versions, expectedStrings);
+            TestGetListCommandUninstallableStrings(versions, ConvertStringInput(expectedStrings));
         }
 
         [MacOsOnlyTheory]
-        [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "", "Required for 1.0 Applications" })]
-        [InlineData(new string[] { "2.3.0", "2.2.0" }, new string[] { "Required for 2.3 Applications", "Required for 2.2 Applications" })]
-        [InlineData(new string[] { "3.1.500", "5.0.1", "5.0.0" }, new string[] { "Required for 3.1 Applications", "Cannot uninstall version 5.0.0 and above", "Cannot uninstall version 5.0.0 and above" })]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "None", "None" })]
+        [InlineData(new string[] { "2.3.0", "2.2.0" }, new string[] { "None", "None" })]
+        [InlineData(new string[] { "3.1.500", "5.0.1", "5.0.0" }, new string[] { "None", "None", "None" })]
         internal void TestGetListCommandUninstallableStringsMac(string[] versions, string[] expectedStrings)
         {
             TestGetListCommandUninstallableStrings(versions, expectedStrings);
@@ -157,7 +147,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
                 bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
             }
 
-            var strings = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(bundles, false);
+            var strings = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(bundles);
 
             strings.Count().Should().Be(bundles.Count());
             strings.Where(pair => !(pair.Key.Version is SdkVersion)).Select(pair => pair.Value).ToList().ForEach(str => str.Should().Be(string.Empty));
@@ -167,30 +157,18 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
             }
         }
 
-        [WindowsOnlyTheory]
-        [InlineData(new string[] { "1.0.1" }, new string[] { "Required by Visual Studio 2017" })]
-        [InlineData(new string[] { "2.3.0", "2.2.0", "2.1.0" }, new string[] { "Required for 2.3 Applications", "Required for 2.2 Applications", "Required by Visual Studio 2017" })]
-        internal void TestGetListCommandUninstallableVerboseStrings(string[] versions, string[] expectedStrings)
+        private string[] ConvertStringInput(string[] input)
         {
-            var bundles = new List<Bundle>
+            var output = new string[input.Length];
+            
+            for (int i = 0; i < input.Length; i++)
             {
-                new Bundle<RuntimeVersion>(new RuntimeVersion(), new BundleArch(), string.Empty, "RuntimeVersion"),
-                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion(), new BundleArch(), string.Empty, "AspNetVersion"),
-                new Bundle<HostingBundleVersion>(new HostingBundleVersion(), new BundleArch(), string.Empty, "HostingBundleVersion")
-            };
-            foreach (string v in versions)
-            {
-                bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
+                output[i] = input[i].Equals("None") ? string.Empty :
+                    SemanticVersion.TryParse(input[i], out var parsed) ? string.Format(LocalizableStrings.UpperLimitRequirement, VisualStudioSafeVersionsExtractor.UpperLimit) :
+                    string.Format(LocalizableStrings.RequirementExplainationString, input[i]);
             }
 
-            var strings = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(bundles, true); 
-
-            strings.Count().Should().Be(bundles.Count());
-            strings.Where(pair => !(pair.Key.Version is SdkVersion)).Select(pair => pair.Value).ToList().ForEach(str => str.Should().Be(string.Empty));
-            for (int i = 0; i < versions.Length; i++)
-            {
-                strings.First(pair => pair.Key.DisplayName.Equals(versions[i])).Value.Length.Should().BeGreaterThan(expectedStrings[i].Length);
-            }
+            return output;
         }
     }
 }

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
             TestGetUninstallable(versions, allowed);
         }
 
-        // TODO For now we are not protecting versions on mac
+        // For now we are not protecting versions on mac
         [MacOsOnlyTheory]
         [InlineData(new string[] { "1.0.0" }, new bool[] { true })]
         [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, true })]

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -21,6 +21,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "2.2.100", "2.2.200" }, new bool[] { false, false })]
         [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
+        [InlineData(new string[] { "3.0.0", "3.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallable(string[] versions, bool[] allowed)
         {
             var bundles = new List<Bundle<SdkVersion>>();
@@ -41,6 +42,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "1.0.0", "1.0.1", "1.0.2" }, new bool[] { true, true, false })]
         [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
+        [InlineData(new string[] { "3.0.0", "3.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableNonSdkVersions(string[] versions, bool[] allowed)
         {
             var bundles = new List<Bundle>
@@ -77,6 +79,35 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
                 {
                     uninstallable.Should().NotContain(fullList[i]);
                 }
+            }
+        }
+
+        [Theory]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "", "[Required by Visual Studio 2017]" })]
+        [InlineData(new string[] { "2.3.0", "2.2.0", "2.1.0" }, new string[] { "[Required for 2.3 Applications]", "[Required for 2.2 Applications]", "[Required by Visual Studio 2017]" })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new string[] { "", "[Required for 1.0 Applications]", "[Required by Visual Studio 2017]" })]
+        [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new string[] { "[Required by Visual Studio 2017]", "", "[Required for 2.1 Applications]" })]
+        [InlineData(new string[] { "2.1.500", "3.0.1", "3.0.0" }, new string[] { "[Required by Visual Studio 2017]", "[Cannot uninstall version 3.0.0 and above]", "[Cannot uninstall version 3.0.0 and above]" })]
+        internal void TestGetListCommandUninstallableStrings(string[] versions, string[] expectedStrings)
+        {
+            var bundles = new List<Bundle>
+            {
+                new Bundle<RuntimeVersion>(new RuntimeVersion(), new BundleArch(), string.Empty, "RuntimeVersion"),
+                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion(), new BundleArch(), string.Empty, "AspNetVersion"),
+                new Bundle<HostingBundleVersion>(new HostingBundleVersion(), new BundleArch(), string.Empty, "HostingBundleVersion")
+            };
+            foreach (string v in versions)
+            {
+                bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
+            }
+
+            var strings = VisualStudioSafeVersionsExtractor.GetListCommandUninstallableStrings(bundles);
+
+            strings.Count().Should().Be(bundles.Count());
+            strings.Where(pair => !(pair.Key.Version is SdkVersion)).Select(pair => pair.Value).ToList().ForEach(str => str.Should().Be(string.Empty));
+            for (int i = 0; i < versions.Length; i++)
+            {
+                strings.First(pair => pair.Key.DisplayName.Equals(versions[i])).Value.Should().Be(expectedStrings[i]);
             }
         }
     }


### PR DESCRIPTION
Restructure commands based on issue #89: Converted root command to "remove", converted option "--dry-run" to command, and added "whatif" command. 
Added upper limit for uninstallation: tool cannot be used for uninstalling sdk version 3.0.0 and above.
Allow explicit uninstallation of required bundles with extra warnings and confirmations.
