### PR TITLE
Visual Studio for Mac version protection

### DIFF
--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -282,6 +282,24 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove.
+        /// </summary>
+        internal static string MacRuntimeRequirementExplainationString {
+            get {
+                return ResourceManager.GetString("MacRuntimeRequirementExplainationString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove.
+        /// </summary>
+        internal static string MacSDKRequirementExplainationString {
+            get {
+                return ResourceManager.GetString("MacSDKRequirementExplainationString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You must specify exactly one version for option: {0}..
         /// </summary>
         internal static string MoreThanOneVersionSpecifiedExceptionMessageFormat {
@@ -367,15 +385,6 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string RequiredBundleConfirmationPromptWarningFormat {
             get {
                 return ResourceManager.GetString("RequiredBundleConfirmationPromptWarningFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove.
-        /// </summary>
-        internal static string RequirementExplainationString {
-            get {
-                return ResourceManager.GetString("RequirementExplainationString", resourceCulture);
             }
         }
         
@@ -664,6 +673,15 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string VersionOptionDescription {
             get {
                 return ResourceManager.GetString("VersionOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove.
+        /// </summary>
+        internal static string WindowsRequirementExplainationString {
+            get {
+                return ResourceManager.GetString("WindowsRequirementExplainationString", resourceCulture);
             }
         }
         

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -127,7 +127,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Force removal of versions that might be used by Visual Studio or SDK..
+        ///   Looks up a localized string similar to Force removal of versions that might be used by Visual Studio for Mac or SDKs..
         /// </summary>
         internal static string ForceOptionDescriptionMac {
             get {
@@ -199,17 +199,6 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-        ///.
-        /// </summary>
-        internal static string ListCommandOutput {
-            get {
-                return ResourceManager.GetString("ListCommandOutput", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to .NET Core Runtimes:.
         /// </summary>
         internal static string ListCommandRuntimeHeader {
@@ -269,6 +258,17 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string ListX86OptionDescription {
             get {
                 return ResourceManager.GetString("ListX86OptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+        ///.
+        /// </summary>
+        internal static string MacListCommandOutput {
+            get {
+                return ResourceManager.GetString("MacListCommandOutput", resourceCulture);
             }
         }
         
@@ -673,6 +673,17 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string VersionOptionDescription {
             get {
                 return ResourceManager.GetString("VersionOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+        ///.
+        /// </summary>
+        internal static string WindowsListCommandOutput {
+            get {
+                return ResourceManager.GetString("WindowsListCommandOutput", resourceCulture);
             }
         }
         

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -327,9 +327,9 @@ Uninstalling this item will cause Visual Studio to break.
     <value>Force removal of versions that might be used by Visual Studio.</value>
   </data>
   <data name="ForceOptionDescriptionMac" xml:space="preserve">
-    <value>Force removal of versions that might be used by Visual Studio or SDK.</value>
+    <value>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</value>
   </data>
-  <data name="ListCommandOutput" xml:space="preserve">
+  <data name="WindowsListCommandOutput" xml:space="preserve">
     <value>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </value>
@@ -342,5 +342,10 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
   </data>
   <data name="MacSDKRequirementExplainationString" xml:space="preserve">
     <value>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</value>
+  </data>
+  <data name="MacListCommandOutput" xml:space="preserve">
+    <value>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -320,7 +320,7 @@ Uninstalling this item will cause Visual Studio to break.
   <data name="UpperLimitRequirement" xml:space="preserve">
     <value>Cannot uninstall version {0} and above</value>
   </data>
-  <data name="RequirementExplainationString" xml:space="preserve">
+  <data name="WindowsRequirementExplainationString" xml:space="preserve">
     <value>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</value>
   </data>
   <data name="ForceOptionDescriptionWindows" xml:space="preserve">
@@ -336,5 +336,11 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
   </data>
   <data name="UninstallNoOptionDescriptionMac" xml:space="preserve">
     <value>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</value>
+  </data>
+  <data name="MacRuntimeRequirementExplainationString" xml:space="preserve">
+    <value>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</value>
+  </data>
+  <data name="MacSDKRequirementExplainationString" xml:space="preserve">
+    <value>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/Shared/Commands/CommandBundleFilter.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/CommandBundleFilter.cs
@@ -11,7 +11,6 @@ using System.Linq;
 using System.CommandLine;
 using Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning;
 using NuGet.Versioning;
-using Microsoft.DotNet.Tools.Uninstall.Shared.Configs.Verbosity;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
 {

--- a/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/ListCommandExec.cs
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             IEnumerable<Bundle> bundles,
             IEnumerable<BundleTypePrintInfo> supportedBundleTypes)
         {
-            Console.WriteLine(LocalizableStrings.ListCommandOutput);
+            Console.WriteLine(RuntimeInfo.RunningOnWindows ? LocalizableStrings.WindowsListCommandOutput : LocalizableStrings.MacListCommandOutput);
 
             var listCommandParseResult = CommandLineConfigs.ListCommand.Parse(Environment.GetCommandLineArgs());
 

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Builder;
 using System.CommandLine.Invocation;
 using System.Linq;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
@@ -227,7 +228,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             DryRunCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => DryRunCommandExec.Execute()));
             RemoveCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => UninstallCommandExec.Execute()));
 
-            CommandLineParseResult = UninstallRootCommand.Parse(Environment.GetCommandLineArgs());
+            var parser = new CommandLineBuilder(UninstallRootCommand)
+                         .Build();
+            CommandLineParseResult = parser.Parse(Environment.GetCommandLineArgs());
         }
 
         public static Option GetUninstallMainOption(this CommandResult commandResult)

--- a/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
+++ b/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
@@ -49,13 +49,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
             var dividedBundles = bundleList
                 .Where(bundle => bundle.Version is RuntimeVersion)
                 .GroupBy(bundle => bundle.Version.MajorMinor)
-                .Select(pair => (pair as IEnumerable<Bundle>, string.Format(LocalizableStrings.RequirementExplainationString, " or SDKs")))
+                .Select(pair => (pair as IEnumerable<Bundle>, string.Format(LocalizableStrings.RequirementExplainationString, " for Mac or SDKs")))
                 .ToDictionary(key => key.Item1, value => value.Item2); 
 
-            var sdks = bundleList.Where(bundle => bundle.Version is SdkVersion); // TODO protect highest SDK-> ok?
+            var sdks = bundleList.Where(bundle => bundle.Version is SdkVersion);
             if (sdks != null && sdks.Count() > 0)
             {
-                dividedBundles.Add(sdks, string.Format(LocalizableStrings.RequirementExplainationString, string.Empty));
+                dividedBundles.Add(sdks, string.Format(LocalizableStrings.RequirementExplainationString, " for Mac"));
             }
 
             var remainingBundles = bundleList

--- a/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
+++ b/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
@@ -16,13 +16,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
         // Pairs are [inclusive, exclusive)
         private static readonly Dictionary<(SemanticVersion, SemanticVersion), string> WindowsVersionDivisionsToExplaination = new Dictionary<(SemanticVersion, SemanticVersion), string>
         {
-            { (new SemanticVersion(1, 0, 0), new SemanticVersion(2, 0, 0)),  string.Format(LocalizableStrings.RequirementExplainationString, "") },
-            { (new SemanticVersion(2, 0, 0), new SemanticVersion(2, 1, 300)), string.Format(LocalizableStrings.RequirementExplainationString, "") },
-            { (new SemanticVersion(2, 1, 300), new SemanticVersion(2, 1, 600)), string.Format(LocalizableStrings.RequirementExplainationString, " 2017") },
-            { (new SemanticVersion(2, 1, 600), new SemanticVersion(2, 1, 900)), string.Format(LocalizableStrings.RequirementExplainationString, " 2019") },
-            { (new SemanticVersion(2, 2, 100), new SemanticVersion(2, 2, 200)), string.Format(LocalizableStrings.RequirementExplainationString, " 2017") },
-            { (new SemanticVersion(2, 2, 200), new SemanticVersion(2, 2, 500)), string.Format(LocalizableStrings.RequirementExplainationString, " 2019") },
-            { (new SemanticVersion(2, 2, 500), UpperLimit), string.Format(LocalizableStrings.RequirementExplainationString, "") }
+            { (new SemanticVersion(1, 0, 0), new SemanticVersion(2, 0, 0)),  string.Format(LocalizableStrings.WindowsRequirementExplainationString, "") },
+            { (new SemanticVersion(2, 0, 0), new SemanticVersion(2, 1, 300)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, "") },
+            { (new SemanticVersion(2, 1, 300), new SemanticVersion(2, 1, 600)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2017") },
+            { (new SemanticVersion(2, 1, 600), new SemanticVersion(2, 1, 900)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2019") },
+            { (new SemanticVersion(2, 2, 100), new SemanticVersion(2, 2, 200)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2017") },
+            { (new SemanticVersion(2, 2, 200), new SemanticVersion(2, 2, 500)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2019") },
+            { (new SemanticVersion(2, 2, 500), UpperLimit), string.Format(LocalizableStrings.WindowsRequirementExplainationString, "") }
         };
 
         private static (IDictionary<IEnumerable<Bundle>, string>, IEnumerable<Bundle>) ApplyWindowsVersionDivisions(IEnumerable<Bundle> bundleList)
@@ -49,13 +49,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
             var dividedBundles = bundleList
                 .Where(bundle => bundle.Version is RuntimeVersion)
                 .GroupBy(bundle => bundle.Version.MajorMinor)
-                .Select(pair => (pair as IEnumerable<Bundle>, string.Format(LocalizableStrings.RequirementExplainationString, " for Mac or SDKs")))
+                .Select(pair => (pair as IEnumerable<Bundle>, LocalizableStrings.MacRuntimeRequirementExplainationString))
                 .ToDictionary(key => key.Item1, value => value.Item2); 
 
             var sdks = bundleList.Where(bundle => bundle.Version is SdkVersion);
             if (sdks != null && sdks.Count() > 0)
             {
-                dividedBundles.Add(sdks, string.Format(LocalizableStrings.RequirementExplainationString, " for Mac"));
+                dividedBundles.Add(sdks, LocalizableStrings.MacSDKRequirementExplainationString);
             }
 
             var remainingBundles = bundleList

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -145,6 +145,16 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacRuntimeRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacSDKRequirementExplainationString">
+        <source>Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio for Mac. Specify individually or use —-force to remove</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>
@@ -204,11 +214,6 @@ Uninstalling this item will cause Visual Studio to break.
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
 </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequirementExplainationString">
-        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
-        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
@@ -369,6 +374,11 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequirementExplainationString">
+        <source>Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</source>
+        <target state="new">Maybe needed for Visual Studio{0}. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="YesOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -57,8 +57,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
-        <source>Force removal of versions that might be used by Visual Studio or SDK.</source>
-        <target state="new">Force removal of versions that might be used by Visual Studio or SDK.</target>
+        <source>Force removal of versions that might be used by Visual Studio for Mac or SDKs.</source>
+        <target state="new">Force removal of versions that might be used by Visual Studio for Mac or SDKs.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionWindows">
@@ -96,15 +96,6 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">.NET Core Runtime &amp; Hosting Bundles:</target>
         <note />
       </trans-unit>
-      <trans-unit id="ListCommandOutput">
-        <source>
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</source>
-        <target state="new">
-This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="ListCommandRuntimeHeader">
         <source>.NET Core Runtimes:</source>
         <target state="new">.NET Core Runtimes:</target>
@@ -138,6 +129,15 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="ListX86OptionDescription">
         <source>List x86 .NET Core SDKs or Runtimes.</source>
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -374,6 +374,15 @@ Uninstalling this item will cause Visual Studio to break.
       <trans-unit id="VersionOptionDescription">
         <source>Display .NET Core Uninstall Tool version information.</source>
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsListCommandOutput">
+        <source>
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</source>
+        <target state="new">
+This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
         <note />
       </trans-unit>
       <trans-unit id="WindowsRequirementExplainationString">

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -8,6 +8,7 @@ using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Commands;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Configs;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Exceptions;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
 using Microsoft.DotNet.Tools.Uninstall.Tests.Attributes;
 using Xunit;
 
@@ -91,12 +92,16 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
             }
             CheckUpperLimitAlwaysRequired(string.Format(command, "--runtime"), runtimeBundles);
 
-            var otherBundles = new List<Bundle>();
-            foreach (string v in versions)
+            if (RuntimeInfo.RunningOnWindows)
             {
-                otherBundles.Add(new Bundle<HostingBundleVersion>(new HostingBundleVersion(v), new BundleArch(), string.Empty, v));
+                // Hosting bundles are only on windows
+                var otherBundles = new List<Bundle>();
+                foreach (string v in versions)
+                {
+                    otherBundles.Add(new Bundle<HostingBundleVersion>(new HostingBundleVersion(v), new BundleArch(), string.Empty, v));
+                }
+                CheckUpperLimitAlwaysRequired(string.Format(command, "--hosting-bundle"), otherBundles);
             }
-            CheckUpperLimitAlwaysRequired(string.Format(command, "--hosting-bundle"), otherBundles);
         }
 
         internal void CheckUpperLimitAlwaysRequired(string command, IEnumerable<Bundle> bundles)

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -15,13 +15,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
 {
     public class CommandBundleFilterTests
     {
-        private static readonly string[] versions = { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1", "10.10.10" };
+        private static readonly string[] versions = { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "5.0.0", "5.0.1", "10.10.10" };
 
         [WindowsOnlyTheory]
-        [InlineData("remove --all --sdk", new string[] { "1.0.0", "1.0.1", "3.0.0"})]
-        [InlineData("dry-run --all --sdk", new string[] { "1.0.0", "1.0.1", "3.0.0" })]
-        [InlineData("whatif --all --sdk", new string[] { "1.0.0", "1.0.1", "3.0.0" })]
-        [InlineData("remove --all-below 5.0.0 --sdk --force", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
+        [InlineData("remove --all --sdk", new string[] { "1.0.0", "1.0.1" })]
+        [InlineData("dry-run --all --sdk", new string[] { "1.0.0", "1.0.1" })]
+        [InlineData("whatif --all --sdk", new string[] { "1.0.0", "1.0.1" })]
+        [InlineData("remove --all-below 5.0.0 --sdk --force", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200" })]
         [InlineData("remove --sdk 1.0.1", new string[] { "1.0.1" })]
         [InlineData("remove --sdk 1.0.0", new string[] { "1.0.0" })]
         [InlineData("remove --sdk 1.0.1 2.1.0 1.0.1", new string[] { "2.1.0", "1.0.1", "1.0.1" })]
@@ -29,48 +29,78 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
             new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200" })]
         internal void TestRequiredUninstallableWhenExplicitlyAddedWindows(string command, string[] expectedUninstallable)
         {
-            TestRequiredUninstallableWhenExplicitlyAdded(command, expectedUninstallable);
+            TestRequiredUninstallableWhenExplicitlyAdded(command, expectedUninstallable, new string[0]);
         }
 
         [MacOsOnlyTheory]
-        [InlineData("remove --all-below 5.0.0 --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })] 
-        [InlineData("dry-run --all-below 5.0.0 --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
-        [InlineData("whatif --all-below 5.0.0 --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "3.0.0", "3.0.1" })]
-        internal void TestRequiredUninstallableWhenExplicitlyAddedMac(string command, string[] expectedUninstallable)
+        [InlineData("remove --all-below 5.0.0 --sdk", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100" }, new string[] { })]
+        [InlineData("remove --all-below 5.0.0 --sdk --force", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200" }, new string[] { })]
+        [InlineData("remove --all-below 5.0.0 --runtime", new string[] { }, new string[] { "1.0.0", "2.1.0", "2.1.500", "2.2.100" })]
+        [InlineData("remove --all-below 5.0.0 --runtime --force", new string[] { }, new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200" })]
+        [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200", new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200" }, new string[] { })]
+        [InlineData("remove --runtime 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200", new string[] { }, new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200" })]
+        internal void TestRequiredUninstallableWhenExplicitlyAddedMac(string command, string[] expectedUninstallableSdk, string[] expectedUninstallableRuntime)
         {
-            TestRequiredUninstallableWhenExplicitlyAdded(command, expectedUninstallable);
+            TestRequiredUninstallableWhenExplicitlyAdded(command, expectedUninstallableSdk, expectedUninstallableRuntime);
         }
 
-        internal void TestRequiredUninstallableWhenExplicitlyAdded(string command, string[] expectedUninstallable)
+        internal void TestRequiredUninstallableWhenExplicitlyAdded(string command, string[] expectedUninstallableSdk, string[] expectedUninstallableRuntime)
         {
-            var bundles = new List<Bundle<SdkVersion>>();
+            var bundles = new List<Bundle>();
             foreach (string v in versions)
             {
                 bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
+                bundles.Add(new Bundle<RuntimeVersion>(new RuntimeVersion(v), new BundleArch(), string.Empty, v));
             }
 
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
-            var uninstallableBundles = CommandBundleFilter.GetFilteredBundles(bundles, parseResult)
-                .Select(b => b.DisplayName);
-            var requiredBundles = versions.Where(v => !uninstallableBundles.Contains(v));
+            var uninstallableBundles = CommandBundleFilter.GetFilteredBundles(bundles, parseResult);
 
-            (uninstallableBundles.Count() + requiredBundles.Count()).Should().Be(versions.Length);
-            uninstallableBundles.ToHashSet().Should().BeEquivalentTo(expectedUninstallable.ToHashSet());
-            requiredBundles.Should().BeEquivalentTo(versions.Where(v => !expectedUninstallable.Contains(v)));
+            var uninstallableSdks = uninstallableBundles.Where(b => b.Version is SdkVersion).Select(b => b.DisplayName);
+            var requiredSdks = bundles.Except(uninstallableBundles).Where(b => b.Version is SdkVersion).Select(b => b.DisplayName);
+            var uninstallableRuntimes = uninstallableBundles.Where(b => b.Version is RuntimeVersion).Select(b => b.DisplayName);
+            var requiredRuntimes = bundles.Except(uninstallableBundles).Where(b => b.Version is RuntimeVersion).Select(b => b.DisplayName);
+
+            (uninstallableSdks.Count() + requiredSdks.Count()).Should().Be(versions.Length);
+            uninstallableSdks.ToHashSet().Should().BeEquivalentTo(expectedUninstallableSdk.ToHashSet());
+            requiredSdks.Should().BeEquivalentTo(versions.Where(v => !expectedUninstallableSdk.Contains(v)));
+
+            (uninstallableRuntimes.Count() + requiredRuntimes.Count()).Should().Be(versions.Length);
+            uninstallableRuntimes.ToHashSet().Should().BeEquivalentTo(expectedUninstallableRuntime.ToHashSet());
+            requiredRuntimes.Should().BeEquivalentTo(versions.Where(v => !expectedUninstallableRuntime.Contains(v)));
         }
 
-        [WindowsOnlyTheory]
-        [InlineData("remove --sdk 10.10.10")]
-        [InlineData("remove --sdk --all --force")]
-        [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 3.0.0 3.0.1 10.10.10")]
-        internal void TestUpperLimitAlwaysRequiredWindows(string command)
+        [Theory]
+        [InlineData("remove {0} 5.0.0")]
+        [InlineData("remove {0} 10.10.10")]
+        [InlineData("remove {0} --all --force")]
+        [InlineData("remove {0} 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 5.0.0 5.0.1 10.10.10")]
+        internal void TestUpperLimitAlwaysRequired(string command)
         {
-            var bundles = new List<Bundle<SdkVersion>>();
+            var sdkBundles = new List<Bundle<SdkVersion>>();
             foreach (string v in versions)
             {
-                bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
+                sdkBundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
             }
+            CheckUpperLimitAlwaysRequired(string.Format(command, "--sdk"), sdkBundles);
 
+            var runtimeBundles = new List<Bundle<RuntimeVersion>>();
+            foreach (string v in versions)
+            {
+                runtimeBundles.Add(new Bundle<RuntimeVersion>(new RuntimeVersion(v), new BundleArch(), string.Empty, v));
+            }
+            CheckUpperLimitAlwaysRequired(string.Format(command, "--runtime"), runtimeBundles);
+
+            var otherBundles = new List<Bundle>();
+            foreach (string v in versions)
+            {
+                otherBundles.Add(new Bundle<HostingBundleVersion>(new HostingBundleVersion(v), new BundleArch(), string.Empty, v));
+            }
+            CheckUpperLimitAlwaysRequired(string.Format(command, "--hosting-bundle"), otherBundles);
+        }
+
+        internal void CheckUpperLimitAlwaysRequired(string command, IEnumerable<Bundle> bundles)
+        {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
             Action filteringAction = () => CommandBundleFilter.GetFilteredBundles(bundles, parseResult);
             filteringAction.Should().Throw<UninstallationNotAllowedException>();

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
     public class VSVersionTests
     {
         [WindowsOnlyTheory]
+        [InlineData(new string[] { }, new bool[] { })]
         [InlineData(new string[] { "1.0.0" }, new bool[] { false })]
         [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
         [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, false })]
@@ -27,31 +28,42 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableWindows(string[] versions, bool[] allowed)
         {
-            TestGetUninstallable(versions, allowed, true);
-        }
-        
-        [MacOsOnlyTheory]
-        [InlineData(new string[] { "1.0.0" }, new bool[] { false })]
-        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
-        [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, false })]
-        [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { false, false, false })]
-        internal void TestGetUninstallableMac(string[] versions, bool[] allowed)
-        {
-            TestGetUninstallable(versions, allowed, false);
-        }
-
-        internal void TestGetUninstallable(string[] versions, bool[] allowed, bool windows)
-        {
             var bundles = new List<Bundle>();
             foreach (string v in versions)
             {
                 bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, string.Empty));
+            }
+
+            var uninstallable = VisualStudioSafeVersionsExtractor.GetUninstallableBundles(bundles);
+
+            CheckAllowed(bundles, uninstallable, allowed, null);
+        }
+
+        [MacOsOnlyTheory]
+        [InlineData(new string[] { }, new bool[] { }, new string[] { }, new bool[] { })]
+        [InlineData(new string[] { "1.0.0" }, new bool[] { false }, new string[] { }, new bool[] { })]
+        [InlineData(new string[] { }, new bool[] { }, new string[] { "1.0.0" }, new bool[] { false })]
+        [InlineData(new string[] { "1.0.0" }, new bool[] { false }, new string[] { "1.0.0" }, new bool[] { false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false }, new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
+        [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, true }, new string[] { "1.0.0", "1.1.0" }, new bool[] { false, false })]
+        [InlineData(new string[] { "3.0.0", "5.0.0" }, new bool[] { false, false }, new string[] { "1.0.0", "1.1.0", "1.0.1", "1.0.2", "1.1.3" }, new bool[] { true, true, true, false, false })]
+        [InlineData(new string[] { "3.0.0", "5.0.0" }, new bool[] { false, false }, new string[] { "1.0.0", "1.1.0", "1.0.1", "5.0.0" }, new bool[] { true, false, false, false })]
+        [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { false, false, false }, new string[] { "5.0.0", "10.0.0" }, new bool[] { false, false })]
+        internal void TestGetUninstallableMac(string[] sdkVersions, bool[] sdkAllowed, string[] runtimeVersions,  bool[] runtimeAllowed)
+        {
+            var bundles = new List<Bundle>();
+            foreach (string v in sdkVersions)
+            {
+                bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, string.Empty));
+            }
+            foreach (string v in runtimeVersions)
+            {
                 bundles.Add(new Bundle<RuntimeVersion>(new RuntimeVersion(v), new BundleArch(), string.Empty, string.Empty));
             }
 
             var uninstallable = VisualStudioSafeVersionsExtractor.GetUninstallableBundles(bundles);
 
-            CheckAllowed(bundles, uninstallable, allowed, windows);
+            CheckAllowed(bundles, uninstallable, sdkAllowed, runtimeAllowed);
         }
 
         [WindowsOnlyTheory]
@@ -64,140 +76,178 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableNonSdkVersionsWindows(string[] versions, bool[] allowed)
         {
-            TestGetUninstallableNonSdkVersions(versions, allowed, true);
-        }
-
-        [MacOsOnlyTheory]
-        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, false, false })]
-        [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { true, true, true })]
-        internal void TestGetUninstallableNonSdkVersionsMac(string[] versions, bool[] allowed)
-        {
-            TestGetUninstallableNonSdkVersions(versions, allowed, false);
-        }
-
-        internal void TestGetUninstallableNonSdkVersions(string[] versions, bool[] allowed, bool windows)
-        {
-            var bundles = new List<Bundle>
-            {
-                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion(), new BundleArch(), string.Empty, "AspNetVersion"),
-                new Bundle<HostingBundleVersion>(new HostingBundleVersion(), new BundleArch(), string.Empty, "HostingBundleVersion")
-            };
+            var bundles = new List<Bundle>();
             foreach (string v in versions)
             {
                 bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
             }
+            TestGetUninstallableNonSdkVersions(bundles, allowed, null);
+        }
+
+        [MacOsOnlyTheory]
+        [InlineData(new string[] { "1.0.0" }, new bool[] { false }, new string[] { "1.0.0" }, new bool[] { false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false }, new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
+        [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, true }, new string[] { "2.0.0", "1.1.0" }, new bool[] { false, false })]
+        [InlineData(new string[] { "3.0.0", "5.0.0" }, new bool[] { false, false }, new string[] { "1.0.0", "1.1.0", "1.0.1", "1.0.2", "1.1.3" }, new bool[] { true, true, true, false, false })]
+        [InlineData(new string[] { "3.0.0", "5.0.0" }, new bool[] { false, false }, new string[] { "1.0.0", "1.1.0", "1.0.1", "5.0.0" }, new bool[] { true, false, false, false })]
+        [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { false, false, false }, new string[] { "5.0.0", "10.0.0" }, new bool[] { false, false })]
+        internal void TestGetUninstallableNonSdkVersionsMac(string[] sdkVersions, bool[] sdkAllowed, string[] runtimeVersions, bool[] runtimeAllowed)
+        {
+            var bundles = new List<Bundle>();
+            foreach (string v in sdkVersions)
+            {
+                bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
+            }
+            foreach (string v in runtimeVersions)
+            {
+                bundles.Add(new Bundle<RuntimeVersion>(new RuntimeVersion(v), new BundleArch(), string.Empty, v));
+            }
+            TestGetUninstallableNonSdkVersions(bundles, sdkAllowed, runtimeAllowed);
+        }
+
+        internal void TestGetUninstallableNonSdkVersions(IEnumerable<Bundle> bundles, bool[] sdkAllowed, bool[] runtimeAllowed)
+        {
+            bundles = bundles.Concat(new List<Bundle>
+            { 
+                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("1.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
+                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("10.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
+                new Bundle<HostingBundleVersion>(new HostingBundleVersion("1.0.0"), new BundleArch(), string.Empty, "HostingBundleVersion"),
+                new Bundle<HostingBundleVersion>(new HostingBundleVersion("10.0.0"), new BundleArch(), string.Empty, "HostingBundleVersion")
+            });
 
             var uninstallable = VisualStudioSafeVersionsExtractor.GetUninstallableBundles(bundles);
 
             // Check that we still have all of the non-sdk bundles
-            bundles.Should().Contain(b => b.Version is AspNetRuntimeVersion);
-            bundles.Should().Contain(b => b.Version is HostingBundleVersion);
+            uninstallable.Where(b => b.Version is AspNetRuntimeVersion).Should().HaveCount(1);
+            uninstallable.Where(b => b.Version is HostingBundleVersion).Should().HaveCount(1);
 
-            CheckAllowed(bundles, uninstallable, allowed, windows);
+            CheckAllowed(bundles, uninstallable, sdkAllowed, runtimeAllowed);
         }
 
-        private void CheckAllowed(IEnumerable<Bundle> bundles, IEnumerable<Bundle> uninstallable, bool[] allowed, bool windows)
+        private void CheckAllowed(IEnumerable<Bundle> bundles, IEnumerable<Bundle> uninstallable, bool[] sdkAllowed, bool[] runtimeAllowed)
         {
-            Bundle[] fullList;
-            if (windows)
+            var sdkBundles = bundles.Where(bundle => bundle.Version is SdkVersion).ToArray();
+            var runtimeBundles = bundles.Where(bundle => bundle.Version is RuntimeVersion).ToArray();
+            var otherBundles = bundles.Except(sdkBundles).Except(runtimeBundles);
+            for (int i = 0; i < sdkBundles.Count(); i++)
             {
-                fullList = bundles.Where(b => b.Version is SdkVersion).ToArray();
-            }
-            else
-            {
-                fullList = bundles.Where(b => b.Version is RuntimeVersion).ToArray();
-            }
-            for (int i = 0; i < fullList.Count(); i++)
-            {
-                if (allowed[i])
+                if (sdkAllowed[i])
                 {
-                    uninstallable.Should().Contain(fullList[i]);
+                    uninstallable.Should().Contain(sdkBundles[i]);
                 }
                 else
                 {
-                    uninstallable.Should().NotContain(fullList[i]);
+                    uninstallable.Should().NotContain(sdkBundles[i]);
+                }
+            }
+            
+            for (int i = 0; i < runtimeBundles.Count(); i++)
+            {
+                if (runtimeAllowed[i])
+                {
+                    uninstallable.Should().Contain(runtimeBundles[i]);
+                }
+                else
+                {
+                    uninstallable.Should().NotContain(runtimeBundles[i]);
+                }
+            }
+            // Check others are uninstallable unless their version is above the upper limit
+            foreach (Bundle bundle in otherBundles)
+            {
+                if (bundle.Version.SemVer > VisualStudioSafeVersionsExtractor.UpperLimit)
+                {
+                    uninstallable.Should().NotContain(bundle);
+                }
+                else
+                {
+                    uninstallable.Should().Contain(bundle);
                 }
             }
         }
 
         [WindowsOnlyTheory]
+        [InlineData(new string[] { }, new string[] { })]
         [InlineData(new string[] { "1.0.1", "1.0.0" }, new string[] { "", "None" })]
         [InlineData(new string[] { "2.3.0", "2.1.800", "2.1.300" }, new string[] { "", " 2019", " 2017" })]
         [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new string[] { " 2017", "None", " 2019" })]
         [InlineData(new string[] { "2.1.500", "5.0.1", "5.0.0" }, new string[] { " 2017", "5.0.0", "5.0.0" })]
         internal void TestGetListCommandUninstallableStringsWindows(string[] versions, string[] expectedStrings)
         {
-            TestGetListCommandUninstallableStrings(versions, ConvertStringInput(expectedStrings, true), true);
-        }
-
-        [MacOsOnlyTheory]
-        [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "None", "" })]
-        [InlineData(new string[] { "2.3.0", "2.2.0" }, new string[] { "", "" })]
-        [InlineData(new string[] { "5.0.0" }, new string[] { "5.0.0" })]
-        [InlineData(new string[] { "3.1.500", "5.0.1", "5.0.0" }, new string[] { "", "5.0.0", "5.0.0" })]
-        internal void TestGetListCommandUninstallableStringsMac(string[] versions, string[] expectedStrings)
-        {
-            TestGetListCommandUninstallableStrings(versions, ConvertStringInput(expectedStrings, false), false);
-        }
-
-        internal void TestGetListCommandUninstallableStrings(string[] versions, string[] expectedStrings, bool windows)
-        {
-            var bundles = new List<Bundle>
-            {
-                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion(), new BundleArch(), string.Empty, "AspNetVersion"),
-                new Bundle<HostingBundleVersion>(new HostingBundleVersion(), new BundleArch(), string.Empty, "HostingBundleVersion")
-            };
+            var bundles = new List<Bundle>();
             foreach (string v in versions)
             {
                 bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
+            }
+
+            TestGetListCommandUninstallableStrings(bundles, ConvertStringInput(expectedStrings), new string[0]);
+        }
+
+        [MacOsOnlyTheory]
+        [InlineData(new string[] { }, new string[] { }, new string[] { }, new string[] { })]
+        [InlineData(new string[] { }, new string[] { }, new string[] { "1.0.0" }, new string[] { " or SDKs" })]
+        [InlineData(new string[] { "1.0.0" }, new string[] { "" }, new string[] { }, new string[] { })]
+        [InlineData(new string[] { "1.0.0" }, new string[] { "" }, new string[] { "1.0.0" }, new string[] { " or SDKs" })]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "None", "" }, new string[] { "1.0.0", "1.0.1" }, new string[] { "None", " or SDKs" })]
+        [InlineData(new string[] { "2.1.0", "1.0.1" }, new string[] { "", "None" }, new string[] { "2.0.0", "1.1.0" }, new string[] { " or SDKs", " or SDKs" })]
+        [InlineData(new string[] { "3.0.0", "5.0.0" }, new string[] { "", "5.0.0" }, new string[] { "1.0.0", "1.1.0", "1.0.1", "1.0.2", "1.1.3" }, new string[] { "None", "None", "None", " or SDKs", " or SDKs" })]
+        [InlineData(new string[] { "3.0.0", "5.0.0" }, new string[] { "", "5.0.0" }, new string[] { "1.0.0", "1.1.0", "1.0.1", "5.0.0" }, new string[] { "None", " or SDKs", " or SDKs", "5.0.0" })]
+        [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new string[] { "5.0.0", "5.0.0", "5.0.0" }, new string[] { "5.0.0", "10.0.0" }, new string[] { "5.0.0", "5.0.0" })]
+        internal void TestGetListCommandUninstallableStringsMac(string[] sdkVersions, string[] sdkExpected, string[] runtimeVersions, string[] runtimeExpected)
+        {
+            var bundles = new List<Bundle>();
+            foreach (string v in sdkVersions)
+            {
+                bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
+            }
+            foreach (string v in runtimeVersions)
+            {
                 bundles.Add(new Bundle<RuntimeVersion>(new RuntimeVersion(v), new BundleArch(), string.Empty, v));
             }
 
-            var strings = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(bundles);
-
-            strings.Count().Should().Be(bundles.Count());
-            // All bundles above the upper limit are required TODO add test cases with this violated
-            strings.Where(pair => pair.Key.Version.SemVer >= VisualStudioSafeVersionsExtractor.UpperLimit)
-                .ToList().ForEach(str => str.Value.Should().Be(string.Format(LocalizableStrings.UpperLimitRequirement, VisualStudioSafeVersionsExtractor.UpperLimit)));
-            if (windows)
-            {
-                // Non-sdk bundles are always uninstallable (below the upper limit
-                strings.Where(pair => !(pair.Key.Version is SdkVersion) && pair.Key.Version.SemVer < VisualStudioSafeVersionsExtractor.UpperLimit)
-                    .Select(pair => pair.Value).ToList().ForEach(str => str.Should().Be(string.Empty));
-            }
-            else
-            {
-                // Non-sdk or runtime bundles are always uninstallable (below the upper limit)
-                strings.Where(pair => !(pair.Key.Version is RuntimeVersion || pair.Key.Version is SdkVersion) && pair.Key.Version.SemVer < VisualStudioSafeVersionsExtractor.UpperLimit)
-                    .Select(pair => pair.Value).ToList().ForEach(str => str.Should().Be(string.Empty));
-            }
-            // Strings are what we expected
-            for (int i = 0; i < versions.Length; i++)
-            {
-                strings.First(pair => pair.Key.DisplayName.Equals(versions[i])).Value.Should().Be(expectedStrings[i]);
-            }
+            TestGetListCommandUninstallableStrings(bundles, ConvertStringInput(sdkExpected), ConvertStringInput(runtimeExpected));
         }
 
-        private string[] ConvertStringInput(string[] input, bool windows)
+        internal void TestGetListCommandUninstallableStrings(IEnumerable<Bundle> bundles, string[] sdkExpected, string[] runtimeExpected)
+        {
+            bundles = bundles.Concat(new List<Bundle>
+            {
+                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("1.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
+                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("10.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
+                new Bundle<HostingBundleVersion>(new HostingBundleVersion("1.0.0"), new BundleArch(), string.Empty, "HostingBundleVersion"),
+                new Bundle<HostingBundleVersion>(new HostingBundleVersion("10.0.0"), new BundleArch(), string.Empty, "HostingBundleVersion")
+            });
+
+            var strings = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(bundles);
+            strings.Count().Should().Be(bundles.Count());
+
+            var sdkBundles = strings.Where(pair => pair.Key.Version is SdkVersion).ToArray();
+            var sdkStrings = sdkBundles.Select(pair => pair.Value);
+            var runtimeBundles = strings.Where(pair => pair.Key.Version is RuntimeVersion).ToArray();
+            var runtimeStrings = runtimeBundles.Select(pair => pair.Value);
+            var otherBundles = strings.Except(sdkBundles).Except(runtimeBundles);
+
+            sdkStrings.Should().BeEquivalentTo(sdkExpected);
+            runtimeStrings.Should().BeEquivalentTo(runtimeExpected);
+
+            otherBundles.Should().HaveCount(4);
+            // All bundles above the upper limit are required
+            otherBundles.Where(pair => pair.Key.Version.SemVer >= VisualStudioSafeVersionsExtractor.UpperLimit)
+                .ToList().ForEach(str => str.Value.Should().Be(string.Format(LocalizableStrings.UpperLimitRequirement, VisualStudioSafeVersionsExtractor.UpperLimit)));
+            // Non-sdk bundles are always uninstallable below the upper limit
+            otherBundles.Where(pair => pair.Key.Version.SemVer < VisualStudioSafeVersionsExtractor.UpperLimit)
+                .ToList().ForEach(str => str.Value.Should().Be(string.Empty));
+        }
+
+        private string[] ConvertStringInput(string[] input)
         {
             var output = new string[input.Length];
             
             for (int i = 0; i < input.Length; i++)
             {
-                if (windows)
-                {
-                    output[i] = input[i].Equals("None") ? string.Empty :
-                        SemanticVersion.TryParse(input[i], out _) ? string.Format(LocalizableStrings.UpperLimitRequirement, VisualStudioSafeVersionsExtractor.UpperLimit) :
-                        string.Format(LocalizableStrings.RequirementExplainationString, input[i]);
-                }
-                else
-                {
-
-                    output[i] = input[i].Equals("None") ? string.Empty :
-                        SemanticVersion.TryParse(input[i], out _) ? string.Format(LocalizableStrings.UpperLimitRequirement, VisualStudioSafeVersionsExtractor.UpperLimit) :
-                        "TODO";
-                }
+                output[i] = input[i].Equals("None") ? string.Empty :
+                    SemanticVersion.TryParse(input[i], out _) ? string.Format(LocalizableStrings.UpperLimitRequirement, VisualStudioSafeVersionsExtractor.UpperLimit) :
+                    string.Format(LocalizableStrings.RequirementExplainationString, input[i]);
             }
 
             return output;

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
 using Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning;
 using Microsoft.DotNet.Tools.Uninstall.Tests.Attributes;
 using NuGet.Versioning;
@@ -247,7 +248,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
             {
                 output[i] = input[i].Equals("None") ? string.Empty :
                     SemanticVersion.TryParse(input[i], out _) ? string.Format(LocalizableStrings.UpperLimitRequirement, VisualStudioSafeVersionsExtractor.UpperLimit) :
-                    string.Format(LocalizableStrings.RequirementExplainationString, input[i]);
+                    string.Format(LocalizableStrings.RequirementExplainationString, RuntimeInfo.RunningOnOSX ? " for Mac" + input[i] : input[i]);
             }
 
             return output;

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -27,31 +27,31 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableWindows(string[] versions, bool[] allowed)
         {
-            TestGetUninstallable(versions, allowed);
+            TestGetUninstallable(versions, allowed, true);
         }
-
-        // TODO For now we are not protecting versions on mac
+        
         [MacOsOnlyTheory]
-        [InlineData(new string[] { "1.0.0" }, new bool[] { true })]
-        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, true })]
-        [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { true, true })]
-        [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { true, true, true })]
+        [InlineData(new string[] { "1.0.0" }, new bool[] { false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
+        [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, false })]
+        [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableMac(string[] versions, bool[] allowed)
         {
-            TestGetUninstallable(versions, allowed);
+            TestGetUninstallable(versions, allowed, false);
         }
 
-        internal void TestGetUninstallable(string[] versions, bool[] allowed)
+        internal void TestGetUninstallable(string[] versions, bool[] allowed, bool windows)
         {
-            var bundles = new List<Bundle<SdkVersion>>();
+            var bundles = new List<Bundle>();
             foreach (string v in versions)
             {
                 bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, string.Empty));
+                bundles.Add(new Bundle<RuntimeVersion>(new RuntimeVersion(v), new BundleArch(), string.Empty, string.Empty));
             }
 
             var uninstallable = VisualStudioSafeVersionsExtractor.GetUninstallableBundles(bundles);
 
-            CheckAllowed(bundles, uninstallable, allowed);
+            CheckAllowed(bundles, uninstallable, allowed, windows);
         }
 
         [WindowsOnlyTheory]
@@ -64,23 +64,22 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableNonSdkVersionsWindows(string[] versions, bool[] allowed)
         {
-            TestGetUninstallableNonSdkVersions(versions, allowed);
+            TestGetUninstallableNonSdkVersions(versions, allowed, true);
         }
 
         [MacOsOnlyTheory]
-        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, true })]
-        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, true, true })]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
+        [InlineData(new string[] { "1.0.0", "1.0.1", "1.1.0" }, new bool[] { true, false, false })]
         [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { true, true, true })]
         internal void TestGetUninstallableNonSdkVersionsMac(string[] versions, bool[] allowed)
         {
-            TestGetUninstallableNonSdkVersions(versions, allowed);
+            TestGetUninstallableNonSdkVersions(versions, allowed, false);
         }
 
-        internal void TestGetUninstallableNonSdkVersions(string[] versions, bool[] allowed)
+        internal void TestGetUninstallableNonSdkVersions(string[] versions, bool[] allowed, bool windows)
         {
             var bundles = new List<Bundle>
             {
-                new Bundle<RuntimeVersion>(new RuntimeVersion(), new BundleArch(), string.Empty, "RuntimeVersion"),
                 new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion(), new BundleArch(), string.Empty, "AspNetVersion"),
                 new Bundle<HostingBundleVersion>(new HostingBundleVersion(), new BundleArch(), string.Empty, "HostingBundleVersion")
             };
@@ -92,16 +91,23 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
             var uninstallable = VisualStudioSafeVersionsExtractor.GetUninstallableBundles(bundles);
 
             // Check that we still have all of the non-sdk bundles
-            bundles.Should().Contain(b => b.Version is RuntimeVersion);
             bundles.Should().Contain(b => b.Version is AspNetRuntimeVersion);
             bundles.Should().Contain(b => b.Version is HostingBundleVersion);
 
-            CheckAllowed(bundles, uninstallable, allowed);
+            CheckAllowed(bundles, uninstallable, allowed, windows);
         }
 
-        private void CheckAllowed(IEnumerable<Bundle> bundles, IEnumerable<Bundle> uninstallable, bool[] allowed)
+        private void CheckAllowed(IEnumerable<Bundle> bundles, IEnumerable<Bundle> uninstallable, bool[] allowed, bool windows)
         {
-            var fullList = bundles.Where(b => b.Version is SdkVersion).ToArray();
+            Bundle[] fullList;
+            if (windows)
+            {
+                fullList = bundles.Where(b => b.Version is SdkVersion).ToArray();
+            }
+            else
+            {
+                fullList = bundles.Where(b => b.Version is RuntimeVersion).ToArray();
+            }
             for (int i = 0; i < fullList.Count(); i++)
             {
                 if (allowed[i])
@@ -122,50 +128,76 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "2.1.500", "5.0.1", "5.0.0" }, new string[] { " 2017", "5.0.0", "5.0.0" })]
         internal void TestGetListCommandUninstallableStringsWindows(string[] versions, string[] expectedStrings)
         {
-            TestGetListCommandUninstallableStrings(versions, ConvertStringInput(expectedStrings));
+            TestGetListCommandUninstallableStrings(versions, ConvertStringInput(expectedStrings, true), true);
         }
 
         [MacOsOnlyTheory]
-        [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "None", "None" })]
-        [InlineData(new string[] { "2.3.0", "2.2.0" }, new string[] { "None", "None" })]
-        [InlineData(new string[] { "3.1.500", "5.0.1", "5.0.0" }, new string[] { "None", "None", "None" })]
+        [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "None", "" })]
+        [InlineData(new string[] { "2.3.0", "2.2.0" }, new string[] { "", "" })]
+        [InlineData(new string[] { "5.0.0" }, new string[] { "5.0.0" })]
+        [InlineData(new string[] { "3.1.500", "5.0.1", "5.0.0" }, new string[] { "", "5.0.0", "5.0.0" })]
         internal void TestGetListCommandUninstallableStringsMac(string[] versions, string[] expectedStrings)
         {
-            TestGetListCommandUninstallableStrings(versions, ConvertStringInput(expectedStrings));
+            TestGetListCommandUninstallableStrings(versions, ConvertStringInput(expectedStrings, false), false);
         }
 
-        internal void TestGetListCommandUninstallableStrings(string[] versions, string[] expectedStrings)
+        internal void TestGetListCommandUninstallableStrings(string[] versions, string[] expectedStrings, bool windows)
         {
             var bundles = new List<Bundle>
             {
-                new Bundle<RuntimeVersion>(new RuntimeVersion(), new BundleArch(), string.Empty, "RuntimeVersion"),
                 new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion(), new BundleArch(), string.Empty, "AspNetVersion"),
                 new Bundle<HostingBundleVersion>(new HostingBundleVersion(), new BundleArch(), string.Empty, "HostingBundleVersion")
             };
             foreach (string v in versions)
             {
                 bundles.Add(new Bundle<SdkVersion>(new SdkVersion(v), new BundleArch(), string.Empty, v));
+                bundles.Add(new Bundle<RuntimeVersion>(new RuntimeVersion(v), new BundleArch(), string.Empty, v));
             }
 
             var strings = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(bundles);
 
             strings.Count().Should().Be(bundles.Count());
-            strings.Where(pair => !(pair.Key.Version is SdkVersion)).Select(pair => pair.Value).ToList().ForEach(str => str.Should().Be(string.Empty));
+            // All bundles above the upper limit are required TODO add test cases with this violated
+            strings.Where(pair => pair.Key.Version.SemVer >= VisualStudioSafeVersionsExtractor.UpperLimit)
+                .ToList().ForEach(str => str.Value.Should().Be(string.Format(LocalizableStrings.UpperLimitRequirement, VisualStudioSafeVersionsExtractor.UpperLimit)));
+            if (windows)
+            {
+                // Non-sdk bundles are always uninstallable (below the upper limit
+                strings.Where(pair => !(pair.Key.Version is SdkVersion) && pair.Key.Version.SemVer < VisualStudioSafeVersionsExtractor.UpperLimit)
+                    .Select(pair => pair.Value).ToList().ForEach(str => str.Should().Be(string.Empty));
+            }
+            else
+            {
+                // Non-sdk or runtime bundles are always uninstallable (below the upper limit)
+                strings.Where(pair => !(pair.Key.Version is RuntimeVersion || pair.Key.Version is SdkVersion) && pair.Key.Version.SemVer < VisualStudioSafeVersionsExtractor.UpperLimit)
+                    .Select(pair => pair.Value).ToList().ForEach(str => str.Should().Be(string.Empty));
+            }
+            // Strings are what we expected
             for (int i = 0; i < versions.Length; i++)
             {
                 strings.First(pair => pair.Key.DisplayName.Equals(versions[i])).Value.Should().Be(expectedStrings[i]);
             }
         }
 
-        private string[] ConvertStringInput(string[] input)
+        private string[] ConvertStringInput(string[] input, bool windows)
         {
             var output = new string[input.Length];
             
             for (int i = 0; i < input.Length; i++)
             {
-                output[i] = input[i].Equals("None") ? string.Empty :
-                    SemanticVersion.TryParse(input[i], out var parsed) ? string.Format(LocalizableStrings.UpperLimitRequirement, VisualStudioSafeVersionsExtractor.UpperLimit) :
-                    string.Format(LocalizableStrings.RequirementExplainationString, input[i]);
+                if (windows)
+                {
+                    output[i] = input[i].Equals("None") ? string.Empty :
+                        SemanticVersion.TryParse(input[i], out _) ? string.Format(LocalizableStrings.UpperLimitRequirement, VisualStudioSafeVersionsExtractor.UpperLimit) :
+                        string.Format(LocalizableStrings.RequirementExplainationString, input[i]);
+                }
+                else
+                {
+
+                    output[i] = input[i].Equals("None") ? string.Empty :
+                        SemanticVersion.TryParse(input[i], out _) ? string.Format(LocalizableStrings.UpperLimitRequirement, VisualStudioSafeVersionsExtractor.UpperLimit) :
+                        "TODO";
+                }
             }
 
             return output;


### PR DESCRIPTION
Adding protection to ensure the tool does not uninstall bundles required by Visual Studio for Mac. Prevents (without the --force option) the user from uninstalling the highest installed major.minor runtime versions and the highest installed sdk version.