### PR TITLE
Adding custom help

### DIFF
--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -88,41 +88,11 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The following items will be removed:
-        ///{0}
-        ///
-        ///To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-        ///
-        ///Do you want to continue? [Y/n] .
-        /// </summary>
-        internal static string ConfirmationPromptOutputFormat {
-            get {
-                return ResourceManager.GetString("ConfirmationPromptOutputFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Display .NET Core SDKs and Runtimes that will be removed..
         /// </summary>
         internal static string DryRunCommandDescription {
             get {
                 return ResourceManager.GetString("DryRunCommandDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to *** DRY RUN OUTPUT
-        ///Specified versions:
-        ///{0}
-        ///*** END DRY RUN OUTPUT
-        ///
-        ///To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-        ///
-        ///Run as administrator and use the remove command to uninstall these items..
-        /// </summary>
-        internal static string DryRunOutputFormat {
-            get {
-                return ResourceManager.GetString("DryRunOutputFormat", resourceCulture);
             }
         }
         
@@ -145,7 +115,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download..
+        ///   Looks up a localized string similar to (*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download..
         /// </summary>
         internal static string HelpExplainationParagraphMac {
             get {
@@ -280,6 +250,36 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The following items will be removed:
+        ///{0}
+        ///
+        ///To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+        ///
+        ///Do you want to continue? [Y/n] .
+        /// </summary>
+        internal static string MacConfirmationPromptOutputFormat {
+            get {
+                return ResourceManager.GetString("MacConfirmationPromptOutputFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to *** DRY RUN OUTPUT
+        ///Specified versions:
+        ///{0}
+        ///*** END DRY RUN OUTPUT
+        ///
+        ///To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+        ///
+        ///Run as administrator and use the remove command to uninstall these items..
+        /// </summary>
+        internal static string MacDryRunOutputFormat {
+            get {
+                return ResourceManager.GetString("MacDryRunOutputFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 
         ///This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
         ///.
@@ -296,6 +296,32 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string MacOsBundleDisplayNameFormat {
             get {
                 return ResourceManager.GetString("MacOsBundleDisplayNameFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///{0}: {1}
+        ///
+        ///Uninstalling this item will cause Visual Studio for Mac to break.
+        ///
+        ///Are you sure you want to continue? [Y/n] .
+        /// </summary>
+        internal static string MacRequiredBundleConfirmationPromptOutputFormat {
+            get {
+                return ResourceManager.GetString("MacRequiredBundleConfirmationPromptOutputFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///Warning: {0}: {1}
+        ///Uninstalling this item will cause Visual Studio for to break.
+        ///.
+        /// </summary>
+        internal static string MacRequiredBundleConfirmationPromptWarningFormat {
+            get {
+                return ResourceManager.GetString("MacRequiredBundleConfirmationPromptWarningFormat", resourceCulture);
             }
         }
         
@@ -381,32 +407,6 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to 
-        ///{0}: {1}
-        ///
-        ///Uninstalling this item will cause Visual Studio to break.
-        ///
-        ///Are you sure you want to continue? [Y/n] .
-        /// </summary>
-        internal static string RequiredBundleConfirmationPromptOutputFormat {
-            get {
-                return ResourceManager.GetString("RequiredBundleConfirmationPromptOutputFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to 
-        ///Warning: {0}: {1}
-        ///Uninstalling this item will cause Visual Studio to break.
-        ///.
-        /// </summary>
-        internal static string RequiredBundleConfirmationPromptWarningFormat {
-            get {
-                return ResourceManager.GetString("RequiredBundleConfirmationPromptWarningFormat", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to The specified version is not found: &quot;{0}&quot;..
         /// </summary>
         internal static string SpecifiedVersionNotFoundExceptionMessageFormat {
@@ -425,7 +425,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain..
+        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*).
         /// </summary>
         internal static string UninstallAllBelowOptionDescription {
             get {
@@ -434,7 +434,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes, except the one highest version..
+        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes, except the one highest version. (*).
         /// </summary>
         internal static string UninstallAllButLatestOptionDescription {
             get {
@@ -452,7 +452,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes, except those specified..
+        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes, except those specified. (*).
         /// </summary>
         internal static string UninstallAllButOptionDescription {
             get {
@@ -461,7 +461,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json..
+        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*).
         /// </summary>
         internal static string UninstallAllLowerPatchesOptionDescription {
             get {
@@ -470,7 +470,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove all .NET Core SDKs or Runtimes..
+        ///   Looks up a localized string similar to Remove all .NET Core SDKs or Runtimes. (*).
         /// </summary>
         internal static string UninstallAllOptionDescription {
             get {
@@ -479,7 +479,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview..
+        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*).
         /// </summary>
         internal static string UninstallAllPreviewsButLatestOptionDescription {
             get {
@@ -488,7 +488,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes marked as previews..
+        ///   Looks up a localized string similar to Remove .NET Core SDKs or Runtimes marked as previews. (*).
         /// </summary>
         internal static string UninstallAllPreviewsOptionDescription {
             get {
@@ -569,7 +569,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall..
+        ///   Looks up a localized string similar to Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall..
         /// </summary>
         internal static string UninstallNoOptionDescriptionMac {
             get {
@@ -695,6 +695,36 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The following items will be removed:
+        ///{0}
+        ///
+        ///To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+        ///
+        ///Do you want to continue? [Y/n] .
+        /// </summary>
+        internal static string WindowsConfirmationPromptOutputFormat {
+            get {
+                return ResourceManager.GetString("WindowsConfirmationPromptOutputFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to *** DRY RUN OUTPUT
+        ///Specified versions:
+        ///{0}
+        ///*** END DRY RUN OUTPUT
+        ///
+        ///To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+        ///
+        ///Run as administrator and use the remove command to uninstall these items..
+        /// </summary>
+        internal static string WindowsDryRunOutputFormat {
+            get {
+                return ResourceManager.GetString("WindowsDryRunOutputFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to 
         ///This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
         ///.
@@ -702,6 +732,32 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string WindowsListCommandOutput {
             get {
                 return ResourceManager.GetString("WindowsListCommandOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///{0}: {1}
+        ///
+        ///Uninstalling this item will cause Visual Studio to break.
+        ///
+        ///Are you sure you want to continue? [Y/n] .
+        /// </summary>
+        internal static string WindowsRequiredBundleConfirmationPromptOutputFormat {
+            get {
+                return ResourceManager.GetString("WindowsRequiredBundleConfirmationPromptOutputFormat", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
+        ///Warning: {0}: {1}
+        ///Uninstalling this item will cause Visual Studio to break.
+        ///.
+        /// </summary>
+        internal static string WindowsRequiredBundleConfirmationPromptWarningFormat {
+            get {
+                return ResourceManager.GetString("WindowsRequiredBundleConfirmationPromptWarningFormat", resourceCulture);
             }
         }
         

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -145,6 +145,24 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to (*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download..
+        /// </summary>
+        internal static string HelpExplainationParagraphMac {
+            get {
+                return ResourceManager.GetString("HelpExplainationParagraphMac", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to (*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download..
+        /// </summary>
+        internal static string HelpExplainationParagraphWindows {
+            get {
+                return ResourceManager.GetString("HelpExplainationParagraphWindows", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &quot;{0}&quot; is treated as a version {1} in this tool..
         /// </summary>
         internal static string HostingBundleFootnoteFormat {

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -154,28 +154,28 @@
     <value>VERSION</value>
   </data>
   <data name="UninstallAllBelowOptionDescription" xml:space="preserve">
-    <value>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</value>
+    <value>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</value>
   </data>
   <data name="UninstallAllButLatestOptionDescription" xml:space="preserve">
-    <value>Remove .NET Core SDKs or Runtimes, except the one highest version.</value>
+    <value>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</value>
   </data>
   <data name="UninstallAllButOptionArgumentName" xml:space="preserve">
     <value>VERSIONS</value>
   </data>
   <data name="UninstallAllButOptionDescription" xml:space="preserve">
-    <value>Remove .NET Core SDKs or Runtimes, except those specified.</value>
+    <value>Remove .NET Core SDKs or Runtimes, except those specified. (*)</value>
   </data>
   <data name="UninstallAllLowerPatchesOptionDescription" xml:space="preserve">
-    <value>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</value>
+    <value>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</value>
   </data>
   <data name="UninstallAllOptionDescription" xml:space="preserve">
-    <value>Remove all .NET Core SDKs or Runtimes.</value>
+    <value>Remove all .NET Core SDKs or Runtimes. (*)</value>
   </data>
   <data name="UninstallAllPreviewsButLatestOptionDescription" xml:space="preserve">
-    <value>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</value>
+    <value>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</value>
   </data>
   <data name="UninstallAllPreviewsOptionDescription" xml:space="preserve">
-    <value>Remove .NET Core SDKs or Runtimes marked as previews.</value>
+    <value>Remove .NET Core SDKs or Runtimes marked as previews. (*)</value>
   </data>
   <data name="UninstallationFailedExceptionMessageFormat" xml:space="preserve">
     <value>Timeout during uninstall: {0}.</value>
@@ -273,7 +273,7 @@
   <data name="YesOptionDescription" xml:space="preserve">
     <value>Execute the command without requiring Y/n confirmation.</value>
   </data>
-  <data name="DryRunOutputFormat" xml:space="preserve">
+  <data name="WindowsDryRunOutputFormat" xml:space="preserve">
     <value>*** DRY RUN OUTPUT
 Specified versions:
 {0}
@@ -283,7 +283,7 @@ To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-co
 
 Run as administrator and use the remove command to uninstall these items.</value>
   </data>
-  <data name="ConfirmationPromptOutputFormat" xml:space="preserve">
+  <data name="WindowsConfirmationPromptOutputFormat" xml:space="preserve">
     <value>The following items will be removed:
 {0}
 
@@ -300,7 +300,7 @@ Do you want to continue? [Y/n] </value>
   <data name="UninstallNotAllowedExceptionFormat" xml:space="preserve">
     <value>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</value>
   </data>
-  <data name="RequiredBundleConfirmationPromptOutputFormat" xml:space="preserve">
+  <data name="WindowsRequiredBundleConfirmationPromptOutputFormat" xml:space="preserve">
     <value>
 {0}: {1}
 
@@ -308,7 +308,7 @@ Uninstalling this item will cause Visual Studio to break.
 
 Are you sure you want to continue? [Y/n] </value>
   </data>
-  <data name="RequiredBundleConfirmationPromptWarningFormat" xml:space="preserve">
+  <data name="WindowsRequiredBundleConfirmationPromptWarningFormat" xml:space="preserve">
     <value>
 Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio to break.
@@ -335,7 +335,7 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
 </value>
   </data>
   <data name="UninstallNoOptionDescriptionMac" xml:space="preserve">
-    <value>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</value>
+    <value>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</value>
   </data>
   <data name="MacRuntimeRequirementExplainationString" xml:space="preserve">
     <value>Maybe needed for Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</value>
@@ -349,9 +349,41 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
 </value>
   </data>
   <data name="HelpExplainationParagraphMac" xml:space="preserve">
-    <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</value>
+    <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</value>
   </data>
   <data name="HelpExplainationParagraphWindows" xml:space="preserve">
     <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</value>
+  </data>
+  <data name="MacConfirmationPromptOutputFormat" xml:space="preserve">
+    <value>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </value>
+  </data>
+  <data name="MacDryRunOutputFormat" xml:space="preserve">
+    <value>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</value>
+  </data>
+  <data name="MacRequiredBundleConfirmationPromptOutputFormat" xml:space="preserve">
+    <value>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </value>
+  </data>
+  <data name="MacRequiredBundleConfirmationPromptWarningFormat" xml:space="preserve">
+    <value>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -337,4 +337,10 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
   <data name="UninstallNoOptionDescriptionMac" xml:space="preserve">
     <value>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</value>
   </data>
+  <data name="HelpExplainationParagraphMac" xml:space="preserve">
+    <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</value>
+  </data>
+  <data name="HelpExplainationParagraphWindows" xml:space="preserve">
+    <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</value>
+  </data>
 </root>

--- a/src/dotnet-core-uninstall/Program.cs
+++ b/src/dotnet-core-uninstall/Program.cs
@@ -10,7 +10,7 @@ namespace Microsoft.DotNet.Tools.Uninstall
     {
         internal static int Main(string[] args)
         {
-            return CommandLineConfigs.UninstallRootCommand.InvokeAsync(args).Result;
+            return CommandLineConfigs.UninstallCommandParser.InvokeAsync(args).Result;
         }
     }
 }

--- a/src/dotnet-core-uninstall/Shared/Commands/DryRunCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/DryRunCommandExec.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using System.Linq;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
 {
@@ -18,12 +19,14 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
         private static void TryIt(IDictionary<Bundle, string> bundles)
         {
             var displayNames = string.Join("\n", bundles.Select(bundle => $"  {bundle.Key.DisplayName}"));
-            Console.WriteLine(string.Format(LocalizableStrings.DryRunOutputFormat, displayNames));
+            Console.WriteLine(string.Format(RuntimeInfo.RunningOnWindows ? 
+                LocalizableStrings.WindowsDryRunOutputFormat : LocalizableStrings.MacDryRunOutputFormat, displayNames));
 
             foreach (var pair in bundles.Where(b => !b.Value.Equals(string.Empty)))
             {
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.Write(string.Format(LocalizableStrings.RequiredBundleConfirmationPromptWarningFormat, pair.Key.DisplayName, pair.Value));
+                Console.Write(string.Format(RuntimeInfo.RunningOnWindows ? LocalizableStrings.WindowsRequiredBundleConfirmationPromptWarningFormat : 
+                    LocalizableStrings.MacRequiredBundleConfirmationPromptWarningFormat, pair.Key.DisplayName, pair.Value));
                 Console.ResetColor();
             }
         }

--- a/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
@@ -210,7 +210,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
         private static bool AskItAndReturnUserAnswer(IDictionary<Bundle, string> bundles)
         {
             var displayNames = string.Join("\n", bundles.Select(bundle => $"  {bundle.Key.DisplayName}"));
-            Console.Write(string.Format(LocalizableStrings.ConfirmationPromptOutputFormat, displayNames));
+            Console.Write(string.Format(RuntimeInfo.RunningOnWindows ? LocalizableStrings.WindowsConfirmationPromptOutputFormat : 
+                LocalizableStrings.MacConfirmationPromptOutputFormat, displayNames));
 
             var response = Console.ReadLine().Trim().ToUpper();
 
@@ -234,7 +235,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
             foreach (var pair in requiredBundles)
             {
                 Console.ForegroundColor = ConsoleColor.Red;
-                Console.Write(string.Format(LocalizableStrings.RequiredBundleConfirmationPromptOutputFormat, pair.Key.DisplayName, pair.Value));
+                Console.Write(string.Format(RuntimeInfo.RunningOnWindows ? LocalizableStrings.WindowsRequiredBundleConfirmationPromptOutputFormat : 
+                    LocalizableStrings.MacRequiredBundleConfirmationPromptOutputFormat, pair.Key.DisplayName, pair.Value));
                 Console.ResetColor();
                 var response = Console.ReadLine().Trim().ToUpper();
                 if (response.Equals("N"))

--- a/src/dotnet-core-uninstall/Shared/Commands/UninstallHelpBuilder.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/UninstallHelpBuilder.cs
@@ -3,19 +3,18 @@ using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
 
 namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
 {
-    public class UninstallHelpBuilder : IHelpBuilder // TODO inherit from helpbuilder once package is updated
+    public class UninstallHelpBuilder : HelpBuilder
     {
-        private readonly IConsole Console;
+        public UninstallHelpBuilder(IConsole console) : base(console) { }
 
-        public UninstallHelpBuilder(IConsole console)
+        public override void Write(ICommand command)
         {
-            Console = console;
-        }
-
-        public void Write(ICommand command)
-        {
-            Console.Out.WriteLine(RuntimeInfo.RunningOnWindows ? LocalizableStrings.HelpExplainationParagraphWindows :
-                LocalizableStrings.HelpExplainationParagraphMac);
+            base.Write(command);
+            if (command.Name.Equals("dry-run") || command.Name.Equals("remove"))
+            {
+                Console.Out.WriteLine(RuntimeInfo.RunningOnWindows ? LocalizableStrings.HelpExplainationParagraphWindows :
+                    LocalizableStrings.HelpExplainationParagraphMac);
+            }
         }
     }
 }

--- a/src/dotnet-core-uninstall/Shared/Commands/UninstallHelpBuilder.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/UninstallHelpBuilder.cs
@@ -1,0 +1,21 @@
+﻿using System.CommandLine;
+using Microsoft.DotNet.Tools.Uninstall.Shared.Utils;
+
+namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
+{
+    public class UninstallHelpBuilder : IHelpBuilder // TODO inherit from helpbuilder once package is updated
+    {
+        private readonly IConsole Console;
+
+        public UninstallHelpBuilder(IConsole console)
+        {
+            Console = console;
+        }
+
+        public void Write(ICommand command)
+        {
+            Console.Out.WriteLine(RuntimeInfo.RunningOnWindows ? LocalizableStrings.HelpExplainationParagraphWindows :
+                LocalizableStrings.HelpExplainationParagraphMac);
+        }
+    }
+}

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -14,6 +14,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 {
     internal static class CommandLineConfigs
     {
+        public static Parser UninstallCommandParser;
+
         private static readonly string ListCommandName = "list";
         private static readonly string DryRunCommandName = "dry-run";
         private static readonly string WhatIfCommandName = "whatif";
@@ -228,9 +230,11 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             DryRunCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => DryRunCommandExec.Execute()));
             RemoveCommand.Handler = CommandHandler.Create(ExceptionHandler.HandleException(() => UninstallCommandExec.Execute()));
 
-            var parser = new CommandLineBuilder(UninstallRootCommand)
-                         .Build();
-            CommandLineParseResult = parser.Parse(Environment.GetCommandLineArgs());
+            UninstallCommandParser = new CommandLineBuilder(UninstallRootCommand)
+                .UseDefaults()
+                .UseHelpBuilder(context => new UninstallHelpBuilder(context.Console))
+                .Build();
+            CommandLineParseResult = UninstallCommandParser.Parse(Environment.GetCommandLineArgs());
         }
 
         public static Option GetUninstallMainOption(this CommandResult commandResult)

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -232,7 +232,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
             UninstallCommandParser = new CommandLineBuilder(UninstallRootCommand)
                 .UseDefaults()
-                .UseHelpBuilder(context => new UninstallHelpBuilder(context.Console))
+                //.UseHelpBuilder(context => new UninstallHelpBuilder(context.Console))
                 .Build();
             CommandLineParseResult = UninstallCommandParser.Parse(Environment.GetCommandLineArgs());
         }

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -232,7 +232,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
             UninstallCommandParser = new CommandLineBuilder(UninstallRootCommand)
                 .UseDefaults()
-                //.UseHelpBuilder(context => new UninstallHelpBuilder(context.Console))
+                .UseHelpBuilder(context => new UninstallHelpBuilder(context.Console))
                 .Build();
             CommandLineParseResult = UninstallCommandParser.Parse(Environment.GetCommandLineArgs());
         }

--- a/src/dotnet-core-uninstall/dotnet-core-uninstall.csproj
+++ b/src/dotnet-core-uninstall/dotnet-core-uninstall.csproj
@@ -14,10 +14,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="2.3.2200-develop-g2d3a6646" />
-    <PackageReference Include="Microsoft.Win32.Registry" Version="4.5.0" />
-    <PackageReference Include="NuGet.Versioning" Version="5.1.0" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19317.1" />
-    <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.19317.1" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
+    <PackageReference Include="NuGet.Versioning" Version="5.3.0" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19405.1" />
+    <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.19405.1" />
     <PackageReference Include="System.Resources.Extensions" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/dotnet-core-uninstall/dotnet-core-uninstall.csproj
+++ b/src/dotnet-core-uninstall/dotnet-core-uninstall.csproj
@@ -15,9 +15,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Setup.Configuration.Interop" Version="2.3.2200-develop-g2d3a6646" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="4.6.0" />
-    <PackageReference Include="NuGet.Versioning" Version="5.3.0" />
-    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19405.1" />
-    <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.19405.1" />
+    <PackageReference Include="NuGet.Versioning" Version="5.3.1" />
+    <PackageReference Include="System.CommandLine.Experimental" Version="0.3.0-alpha.19573.2" />
+    <PackageReference Include="System.CommandLine.Rendering" Version="0.3.0-alpha.19573.2" />
     <PackageReference Include="System.Resources.Extensions" Version="4.6.0" />
   </ItemGroup>
 

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -17,43 +17,9 @@
         <target state="new">Allowed values are "Y" and "n".</target>
         <note />
       </trans-unit>
-      <trans-unit id="ConfirmationPromptOutputFormat">
-        <source>The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </source>
-        <target state="new">The following items will be removed:
-{0}
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Do you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
       <trans-unit id="DryRunCommandDescription">
         <source>Display .NET Core SDKs and Runtimes that will be removed.</source>
         <target state="new">Display .NET Core SDKs and Runtimes that will be removed.</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="DryRunOutputFormat">
-        <source>*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</source>
-        <target state="new">*** DRY RUN OUTPUT
-Specified versions:
-{0}
-*** END DRY RUN OUTPUT
-
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
-
-Run as administrator and use the remove command to uninstall these items.</target>
         <note />
       </trans-unit>
       <trans-unit id="ForceOptionDescriptionMac">
@@ -67,8 +33,8 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplainationParagraphWindows">
@@ -141,6 +107,40 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">List x86 .NET Core SDKs or Runtimes.</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
@@ -153,6 +153,32 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} (x64)</source>
         <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio for Mac to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="MacRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio for to break.
+</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRuntimeRequirementExplainationString">
@@ -200,32 +226,6 @@ This tool can not uninstall versions of the runtime or SDK that are installed us
         <target state="new">Required argument missing for the uninstall command.</target>
         <note />
       </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptOutputFormat">
-        <source>
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </source>
-        <target state="new">
-{0}: {1}
-
-Uninstalling this item will cause Visual Studio to break.
-
-Are you sure you want to continue? [Y/n] </target>
-        <note />
-      </trans-unit>
-      <trans-unit id="RequiredBundleConfirmationPromptWarningFormat">
-        <source>
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</source>
-        <target state="new">
-Warning: {0}: {1}
-Uninstalling this item will cause Visual Studio to break.
-</target>
-        <note />
-      </trans-unit>
       <trans-unit id="SpecifiedVersionNotFoundExceptionMessageFormat">
         <source>The specified version is not found: "{0}".</source>
         <target state="new">The specified version is not found: "{0}".</target>
@@ -237,13 +237,13 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllBelowOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain.</target>
+        <source>Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes below the specified version. The specified version will remain. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except the one highest version.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except the one highest version. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionArgumentName">
@@ -252,28 +252,28 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllButOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes, except those specified.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified.</target>
+        <source>Remove .NET Core SDKs or Runtimes, except those specified. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes, except those specified. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllLowerPatchesOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json.</target>
+        <source>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes.</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes.</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsOptionDescription">
-        <source>Remove .NET Core SDKs or Runtimes marked as previews.</source>
-        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews.</target>
+        <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
+        <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">
@@ -307,8 +307,8 @@ Uninstalling this item will cause Visual Studio to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
@@ -386,12 +386,72 @@ Uninstalling this item will cause Visual Studio to break.
         <target state="new">Display .NET Core Uninstall Tool version information.</target>
         <note />
       </trans-unit>
+      <trans-unit id="WindowsConfirmationPromptOutputFormat">
+        <source>The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </source>
+        <target state="new">The following items will be removed:
+{0}
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Do you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsDryRunOutputFormat">
+        <source>*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</source>
+        <target state="new">*** DRY RUN OUTPUT
+Specified versions:
+{0}
+*** END DRY RUN OUTPUT
+
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+
+Run as administrator and use the remove command to uninstall these items.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="WindowsListCommandOutput">
         <source>
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
 </source>
         <target state="new">
 This tool can not uninstall versions of the runtime or SDK that are installed using Visual Studio 2019 Update 3 or via zip/scripts. The versions that can be uninstalled with this tool are:
+</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptOutputFormat">
+        <source>
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </source>
+        <target state="new">
+{0}: {1}
+
+Uninstalling this item will cause Visual Studio to break.
+
+Are you sure you want to continue? [Y/n] </target>
+        <note />
+      </trans-unit>
+      <trans-unit id="WindowsRequiredBundleConfirmationPromptWarningFormat">
+        <source>
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
+</source>
+        <target state="new">
+Warning: {0}: {1}
+Uninstalling this item will cause Visual Studio to break.
 </target>
         <note />
       </trans-unit>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -66,6 +66,16 @@ Run as administrator and use the remove command to uninstall these items.</targe
         <target state="new">Force removal of versions that might be used by Visual Studio.</target>
         <note />
       </trans-unit>
+      <trans-unit id="HelpExplainationParagraphMac">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="HelpExplainationParagraphWindows">
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">
         <source>"{0}" is treated as a version {1} in this tool.</source>
         <target state="new">"{0}" is treated as a version {1} in this tool.</target>

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.CommandLine;
+using System.CommandLine.Invocation;
 using System.Linq;
 using FluentAssertions;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
@@ -110,5 +111,16 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
             Action filteringAction = () => CommandBundleFilter.GetFilteredBundles(bundles, parseResult);
             filteringAction.Should().Throw<UninstallationNotAllowedException>();
         }
+
+        [Fact]
+        public void TestHelpOutputContainsExplainationParagraph()
+        {
+            var console = new TestConsole();
+            _ = CommandLineConfigs.UninstallCommandParser.InvokeAsync("-h", console).Result;
+
+            console.Out.ToString().Should().Contain(RuntimeInfo.RunningOnWindows ? LocalizableStrings.HelpExplainationParagraphWindows : 
+                LocalizableStrings.HelpExplainationParagraphMac);
+        }
+
     }
 }

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -115,11 +115,14 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
         [Fact]
         public void TestHelpOutputContainsExplainationParagraph()
         {
-            var console = new TestConsole();
-            _ = CommandLineConfigs.UninstallCommandParser.InvokeAsync("-h", console).Result;
+            foreach (var command in new string[] { "dry-run -h", "whatif -h", "remove -h" }) 
+            {
+                var console = new TestConsole();
+                _ = CommandLineConfigs.UninstallCommandParser.InvokeAsync(command, console).Result;
 
-            console.Out.ToString().Should().Contain(RuntimeInfo.RunningOnWindows ? LocalizableStrings.HelpExplainationParagraphWindows : 
-                LocalizableStrings.HelpExplainationParagraphMac);
+                console.Out.ToString().Should().Contain(RuntimeInfo.RunningOnWindows ? LocalizableStrings.HelpExplainationParagraphWindows :
+                    LocalizableStrings.HelpExplainationParagraphMac);
+            }
         }
 
     }


### PR DESCRIPTION
Adding a paragraph to the bottom of `whatif --help`, `dry-run --help`, and `remove --help` with information about Visual Studio/Visual Studio for Mac version protection. New help output:

![Screenshot (5)](https://user-images.githubusercontent.com/16010855/69564763-790afc80-0f68-11ea-8e93-4d59f00ba660.png)

cc @KathleenDollard 