### PR TITLE
Fix version string spacing issue

### DIFF
--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -253,7 +253,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         ///   Looks up a localized string similar to The following items will be removed:
         ///{0}
         ///
-        ///To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+        ///To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
         ///
         ///Do you want to continue? [y/n] .
         /// </summary>
@@ -269,7 +269,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         ///{0}
         ///*** END DRY RUN OUTPUT
         ///
-        ///To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+        ///To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
         ///
         ///Run as administrator and use the remove command to uninstall these items..
         /// </summary>
@@ -281,7 +281,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///This tool can not uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
+        ///This tool cannot uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:
         ///.
         /// </summary>
         internal static string MacListCommandOutput {
@@ -362,7 +362,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall..
+        ///   Looks up a localized string similar to The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs..
         /// </summary>
         internal static string NotAdminExceptionMessage {
             get {
@@ -569,7 +569,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall..
+        ///   Looks up a localized string similar to Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs..
         /// </summary>
         internal static string UninstallNoOptionDescriptionMac {
             get {
@@ -578,7 +578,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall..
+        ///   Looks up a localized string similar to Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs..
         /// </summary>
         internal static string UninstallNoOptionDescriptionWindows {
             get {
@@ -698,7 +698,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         ///   Looks up a localized string similar to The following items will be removed:
         ///{0}
         ///
-        ///To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+        ///To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
         ///
         ///Do you want to continue? [y/n] .
         /// </summary>
@@ -714,7 +714,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         ///{0}
         ///*** END DRY RUN OUTPUT
         ///
-        ///To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+        ///To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
         ///
         ///Run as administrator and use the remove command to uninstall these items..
         /// </summary>
@@ -726,7 +726,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         
         /// <summary>
         ///   Looks up a localized string similar to 
-        ///This tool can not uninstall versions of the runtime or SDK that are 
+        ///This tool cannot uninstall versions of the runtime or SDK that are 
         ///    - SDKs installed using Visual Studio 2019 Update 3 or later.
         ///    - SDKs and runtimes installed via zip/scripts.
         ///    - Runtimes installed with SDKs (these should be removed by removing that SDK).

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -196,7 +196,7 @@
     <value>VERSION</value>
   </data>
   <data name="UninstallNoOptionDescriptionWindows" xml:space="preserve">
-    <value>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</value>
+    <value>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</value>
   </data>
   <data name="VerbosityOptionArgumentName" xml:space="preserve">
     <value>LEVEL</value>
@@ -211,7 +211,7 @@
     <value>Can be used with --sdk, --runtime and --aspnet-runtime to remove x86.</value>
   </data>
   <data name="NotAdminExceptionMessage" xml:space="preserve">
-    <value>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</value>
+    <value>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</value>
   </data>
   <data name="MoreThanOneVersionSpecifiedExceptionMessageFormat" xml:space="preserve">
     <value>You must specify exactly one version for option: {0}.</value>
@@ -279,7 +279,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</value>
   </data>
@@ -287,7 +287,7 @@ Run as administrator and use the remove command to uninstall these items.</value
     <value>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </value>
   </data>
@@ -339,7 +339,7 @@ The versions that can be uninstalled with this tool are:
 </value>
   </data>
   <data name="UninstallNoOptionDescriptionMac" xml:space="preserve">
-    <value>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</value>
+    <value>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</value>
   </data>
   <data name="MacRuntimeRequirementExplainationString" xml:space="preserve">
     <value>Used by Visual Studio for Mac or SDKs. Specify individually or use —-force to remove</value>
@@ -362,7 +362,7 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
     <value>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </value>
   </data>
@@ -372,7 +372,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</value>
   </data>

--- a/src/dotnet-core-uninstall/Shared/BundleInfo/Versioning/BundleVersion.cs
+++ b/src/dotnet-core-uninstall/Shared/BundleInfo/Versioning/BundleVersion.cs
@@ -34,7 +34,11 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning
             {
                 SemVer = semVer;
             }
-            else
+            else if(value != null && SemanticVersion.TryParse(value.Replace(" ", ""), out var formattedSemVer))
+            {
+                SemVer = formattedSemVer;
+            }
+            else 
             {
                 throw new InvalidInputVersionException(value);
             }

--- a/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/UninstallCommandExec.cs
@@ -36,7 +36,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
 
             var filtered = CommandBundleFilter.GetFilteredWithRequirementStrings(bundleCollector);
 
-            if (CommandLineConfigs.CommandLineParseResult.CommandResult.OptionResult(CommandLineConfigs.YesOption.Name) != null)
+            if (CommandLineConfigs.CommandLineParseResult.FindResultFor(CommandLineConfigs.YesOption) != null)
             {
                 if (!IsAdmin())
                 {

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -111,13 +111,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -128,7 +128,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -136,7 +136,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -202,8 +202,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="NotAdminExceptionMessage">
-        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall.</target>
+        <source>The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">The current user does not have adequate privileges. See https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="OperatingSystemNotSupportedExceptionMessage">
@@ -307,13 +307,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionMac">
-        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. By default, this tool does not uninstall versions that might be needed for Visual Studio for Mac or SDKs. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNoOptionDescriptionWindows">
-        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</source>
-        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall.</target>
+        <source>Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</source>
+        <target state="new">Remove specified .NET Core SDKs or Runtimes. This tool can only uninstall items that were installed using Visual Studio, .NET Core SDK, or Runtime installers. By default, this tool does not uninstall versions that might be needed for Visual Studio. Read the documentation for the .NET Core Uninstall Tool at https://aka.ms/dotnet-core-uninstall-docs.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallNormalVerbosityFormat">
@@ -390,13 +390,13 @@ Uninstalling this item will cause Visual Studio for to break.
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -407,7 +407,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -415,7 +415,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall.
+To avoid breaking Visual Studio or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />


### PR DESCRIPTION
Fixing 3 small issues discovered by manual testers (each in different commits):

- Docs link in command line output is out of date
- Version strings are rejected if they contain spaces
- `--yes` option is ignored