### PR TITLE
Fix incorrect path used to find bundled x64 runtimes on Arm64

### DIFF
--- a/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
+++ b/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
@@ -40,10 +40,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
                 sdks = sdks.Concat(GetInstalledBundles<SdkVersion>(BundleArch.X64, DotNetSdkInstallPath(EmulatedDotNetInstallPath)));
                 runtimes = runtimes.Concat(GetInstalledBundles<RuntimeVersion>(
                     BundleArch.X64,
-                    DotNetRuntimeInstallPath(DotNetInstallPath),
-                    DotNetAspAllInstallPath(DotNetInstallPath),
-                    DotNetAspAppInstallPath(DotNetInstallPath),
-                    DotNetHostFxrInstallPath(DotNetInstallPath)));
+                    DotNetRuntimeInstallPath(EmulatedDotNetInstallPath),
+                    DotNetAspAllInstallPath(EmulatedDotNetInstallPath),
+                    DotNetAspAppInstallPath(EmulatedDotNetInstallPath),
+                    DotNetHostFxrInstallPath(EmulatedDotNetInstallPath)));
             }
 
             return sdks.Concat(runtimes).ToList();


### PR DESCRIPTION
The wrong runtimes were resolved for dotnet x64 on Arm64 machines.
The FileSystemExplorer was using the dotnet Arm64 path
/usr/local/share/dotnet to find the x64 runtimes, instead of the
emulated dotnet install path.