### PR TITLE
allow management of 7.0 SDKs and Runtimes

### DIFF
--- a/src/dotnet-core-uninstall/Shared/BundleInfo/Bundle.cs
+++ b/src/dotnet-core-uninstall/Shared/BundleInfo/Bundle.cs
@@ -54,6 +54,11 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo
         {
             return $"{Version.ToString()} ({Arch.ToString().ToLower()})";
         }
+
+        public virtual string ToDebugString()
+        {
+            return $"{Version.ToString()} ({Arch.ToString().ToLower()})";
+        }
     }
 
     internal class Bundle<TBundleVersion> : Bundle, IComparable, IComparable<Bundle>, IEquatable<Bundle<TBundleVersion>>
@@ -103,6 +108,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo
         public override int GetHashCode()
         {
             return HashCode.Combine(base.GetHashCode());
+        }
+
+        public override string ToDebugString() {
+            return $"{nameof(TBundleVersion)} {Version.ToString()} ({Arch.ToString().ToLower()}) - {UninstallCommand ?? "n/a"}";
         }
     }
 }

--- a/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
+++ b/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
@@ -25,7 +25,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
             { (new SemanticVersion(2, 1, 600), new SemanticVersion(2, 1, 900)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2019") },
             { (new SemanticVersion(2, 2, 100), new SemanticVersion(2, 2, 200)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2017") },
             { (new SemanticVersion(2, 2, 200), new SemanticVersion(2, 2, 500)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2019") },
-            { (new SemanticVersion(3, 1, 100), new SemanticVersion(5, 0, 600)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2019") },
+            { (new SemanticVersion(3, 0, 100), new SemanticVersion(5, 0, 600)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2019") },
             { (new SemanticVersion(6, 0, 100), UpperLimit), string.Format(LocalizableStrings.WindowsRequirementExplainationString, "") }
         };
 

--- a/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
+++ b/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
@@ -25,7 +25,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
             { (new SemanticVersion(2, 1, 600), new SemanticVersion(2, 1, 900)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2019") },
             { (new SemanticVersion(2, 2, 100), new SemanticVersion(2, 2, 200)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2017") },
             { (new SemanticVersion(2, 2, 200), new SemanticVersion(2, 2, 500)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2019") },
-            { (new SemanticVersion(2, 2, 500), UpperLimit), string.Format(LocalizableStrings.WindowsRequirementExplainationString, "") }
+            { (new SemanticVersion(3, 1, 100), new SemanticVersion(5, 0, 600)), string.Format(LocalizableStrings.WindowsRequirementExplainationString, " 2019") },
+            { (new SemanticVersion(6, 0, 100), UpperLimit), string.Format(LocalizableStrings.WindowsRequirementExplainationString, "") }
         };
 
         private static (IDictionary<IEnumerable<Bundle>, string>, IEnumerable<Bundle>) ApplyWindowsVersionDivisions(IEnumerable<Bundle> bundleList)

--- a/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
+++ b/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
     internal static class VisualStudioSafeVersionsExtractor
     {
         // The tool should not be used to uninstall any more recent versions of the sdk
-        public static readonly SemanticVersion UpperLimit = new SemanticVersion(7, 0, 0);
+        public static readonly SemanticVersion UpperLimit = new SemanticVersion(8, 0, 0);
 
         // Must keep one of each of these divisions to ensure Visual Studio works. 
         // Pairs are [inclusive, exclusive)

--- a/src/dotnet-core-uninstall/dotnet-core-uninstall.csproj
+++ b/src/dotnet-core-uninstall/dotnet-core-uninstall.csproj
@@ -5,6 +5,7 @@
     <RuntimeIdentifiers>win-x86;osx-x64</RuntimeIdentifiers>
     <SignAssembly>true</SignAssembly>
     <TargetFramework>netcoreapp3.1</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -6,6 +6,7 @@ using System.CommandLine.IO;
 using System.CommandLine.Parsing;
 using System.Linq;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
 using Microsoft.DotNet.Tools.Uninstall.Shared.Commands;
@@ -103,8 +104,14 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
 
         internal void TestRequiredUninstallableWhenExplicitlyAdded(IEnumerable<Bundle> bundles, string command, string[] expectedUninstallableSdk, string[] expectedUninstallableRuntime)
         {
+            using var scope = new AssertionScope();
+            scope.AddReportable("bundles", () => String.Join(Environment.NewLine, bundles.Select(b => b.ToDebugString())));
+            scope.AddReportable("command", () => command);
+            scope.AddReportable("expectedUninstallableSdk", () => String.Join(Environment.NewLine, expectedUninstallableSdk));
+            scope.AddReportable("expectedUninstallableRuntime", () => String.Join(Environment.NewLine, expectedUninstallableRuntime));
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
             var uninstallableBundles = CommandBundleFilter.GetFilteredBundles(bundles, parseResult);
+            scope.AddReportable("uninstallableBundles", () => String.Join(Environment.NewLine, uninstallableBundles.Select(b => b.ToDebugString())));
 
             var uninstallableSdks = uninstallableBundles.Where(b => b.Version is SdkVersion).Select(b => b.DisplayName);
             var requiredSdks = bundles.Except(uninstallableBundles).Where(b => b.Version is SdkVersion).Select(b => b.DisplayName);

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
 {
     public class CommandBundleFilterTests
     {
-        private static readonly string[] versions = { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "5.0.0", "7.0.1", "10.10.10" };
+        private static readonly string[] versions = { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "5.0.0", "7.0.1", "8.0.1", "10.10.10" };
         private Dictionary<string, BundleArch> versionsWithArch = new Dictionary<string, BundleArch>
         {
             { "3.0.0", BundleArch.X64 },
@@ -42,7 +42,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
         [InlineData("remove --sdk 1.0.1", new string[] { "1.0.1" })]
         [InlineData("remove --sdk 1.0.0", new string[] { "1.0.0" })]
         [InlineData("remove --sdk 1.0.1 2.1.0 1.0.1", new string[] { "2.1.0", "1.0.1", "1.0.1" })]
-        [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200", 
+        [InlineData("remove --sdk 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200",
             new string[] { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200" })]
         internal void TestRequiredUninstallableWhenExplicitlyAddedWindows(string command, string[] expectedUninstallable)
         {
@@ -122,7 +122,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
         }
 
         [Theory]
-        [InlineData("remove {0} 7.0.1")]
+        [InlineData("remove {0} 8.0.1")]
         [InlineData("remove {0} 10.10.10")]
         [InlineData("remove {0} --all --force")]
         [InlineData("remove {0} 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 5.0.0 7.0.1 10.10.10")]
@@ -158,13 +158,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
         {
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
             Action filteringAction = () => CommandBundleFilter.GetFilteredBundles(bundles, parseResult);
-            filteringAction.Should().Throw<UninstallationNotAllowedException>();
+            filteringAction.Should().Throw<UninstallationNotAllowedException>("Expected command '{0}' to fail when the following bundles were installed: {1}", command, String.Join(", ", bundles.Select(b => b.DisplayName).ToList()));
         }
 
         [Fact]
         public void TestHelpOutputContainsExplainationParagraph()
         {
-            foreach (var command in new string[] { "dry-run -h", "whatif -h", "remove -h" }) 
+            foreach (var command in new string[] { "dry-run -h", "whatif -h", "remove -h" })
             {
                 var console = new TestConsole();
                 _ = CommandLineConfigs.UninstallCommandParser.InvokeAsync(command, console).Result;

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using FluentAssertions;
+using FluentAssertions.Execution;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo.Versioning;
 using Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning;
@@ -26,7 +28,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "3.0.0", "3.0.1", "5.0.0" }, new bool[] { true, true, false })]
         [InlineData(new string[] { "5.0.0", "5.0.1", "6.0.1" }, new bool[] { true, true, false })]
-        [InlineData(new string[] { "6.0.0", "6.0.1", "7.0.0" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "6.0.0", "6.0.1", "7.0.0" }, new bool[] { true, true, false })]
         [InlineData(new string[] { "9.0.0", "9.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableWindows(string[] versions, bool[] allowed)
         {
@@ -48,7 +50,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "1.0.0" }, new bool[] { false }, new string[] { "1.0.0" }, new bool[] { false })]
         [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false }, new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
         [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, true }, new string[] { "1.0.0", "1.1.0" }, new bool[] { false, false })]
-        [InlineData(new string[] { "3.0.0", "7.0.0" }, new bool[] { false, false }, new string[] { "1.0.0", "1.1.0", "1.0.1", "1.0.2", "1.1.3" }, new bool[] { true, true, true, false, false })]
+        [InlineData(new string[] { "3.0.0", "7.0.0" }, new bool[] { false, true }, new string[] { "1.0.0", "1.1.0", "1.0.1", "1.0.2", "1.1.3" }, new bool[] { true, true, true, false, false })]
         [InlineData(new string[] { "3.0.0", "5.0.0" }, new bool[] { true, false }, new string[] { "1.0.0", "1.1.0", "1.0.1", "5.0.0" }, new bool[] { true, false, false, false })]
         [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { true, false, false }, new string[] { "5.0.0", "10.0.0" }, new bool[] { false, false })]
         [InlineData(new string[] { "5.0.0", "6.0.0", "6.0.1" }, new bool[] { true, true, false }, new string[] { "5.0.0" }, new bool[] { false })]
@@ -113,7 +115,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         internal void TestGetUninstallableNonSdkVersions(IEnumerable<Bundle> bundles, bool[] sdkAllowed, bool[] runtimeAllowed)
         {
             bundles = bundles.Concat(new List<Bundle>
-            { 
+            {
                 new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("1.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
                 new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("10.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
                 new Bundle<HostingBundleVersion>(new HostingBundleVersion("1.0.0"), new BundleArch(), string.Empty, "HostingBundleVersion"),
@@ -129,32 +131,35 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
             CheckAllowed(bundles, uninstallable, sdkAllowed, runtimeAllowed);
         }
 
-        private void CheckAllowed(IEnumerable<Bundle> bundles, IEnumerable<Bundle> uninstallable, bool[] sdkAllowed, bool[] runtimeAllowed)
+        private void CheckAllowed(IEnumerable<Bundle> allBundles, IEnumerable<Bundle> uninstallableBundles, bool[] sdkAllowed, bool[] runtimeAllowed)
         {
-            var sdkBundles = bundles.Where(bundle => bundle.Version is SdkVersion).ToArray();
-            var runtimeBundles = bundles.Where(bundle => bundle.Version is RuntimeVersion).ToArray();
-            var otherBundles = bundles.Except(sdkBundles).Except(runtimeBundles);
+            using var scope = new AssertionScope();
+            scope.AddReportable("allBundles", () => String.Join(Environment.NewLine, allBundles.Select(b => b.ToDebugString())));
+            scope.AddReportable("uninstallableBundles", () => String.Join(Environment.NewLine, uninstallableBundles.Select(b => b.ToDebugString())));
+            var sdkBundles = allBundles.Where(bundle => bundle.Version is SdkVersion).ToArray();
+            var runtimeBundles = allBundles.Where(bundle => bundle.Version is RuntimeVersion).ToArray();
+            var otherBundles = allBundles.Except(sdkBundles).Except(runtimeBundles);
             for (int i = 0; i < sdkBundles.Count(); i++)
             {
                 if (sdkAllowed[i])
                 {
-                    uninstallable.Should().Contain(sdkBundles[i]);
+                    uninstallableBundles.Should().Contain(sdkBundles[i]);
                 }
                 else
                 {
-                    uninstallable.Should().NotContain(sdkBundles[i]);
+                    uninstallableBundles.Should().NotContain(sdkBundles[i]);
                 }
             }
-            
+
             for (int i = 0; i < runtimeBundles.Count(); i++)
             {
                 if (runtimeAllowed[i])
                 {
-                    uninstallable.Should().Contain(runtimeBundles[i]);
+                    uninstallableBundles.Should().Contain(runtimeBundles[i]);
                 }
                 else
                 {
-                    uninstallable.Should().NotContain(runtimeBundles[i]);
+                    uninstallableBundles.Should().NotContain(runtimeBundles[i]);
                 }
             }
             // Check others are uninstallable unless their version is above the upper limit
@@ -162,11 +167,11 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
             {
                 if (bundle.Version.SemVer > VisualStudioSafeVersionsExtractor.UpperLimit)
                 {
-                    uninstallable.Should().NotContain(bundle);
+                    uninstallableBundles.Should().NotContain(bundle);
                 }
                 else
                 {
-                    uninstallable.Should().Contain(bundle);
+                    uninstallableBundles.Should().Contain(bundle);
                 }
             }
         }
@@ -262,7 +267,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
                 { "Runtime", LocalizableStrings.MacRuntimeRequirementExplainationString}
             };
             var output = new string[input.Length];
-            
+
             for (int i = 0; i < input.Length; i++)
             {
                 output[i] = shortHandToFullExpectedString[input[i]];

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -27,7 +27,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "2.2.100", "2.2.200" }, new bool[] { false, false })]
         [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "3.0.0", "3.0.1", "5.0.0" }, new bool[] { true, true, false })]
-        [InlineData(new string[] { "5.0.0", "5.0.1", "6.0.1" }, new bool[] { true, true, false })]
+        [InlineData(new string[] { "5.0.0", "5.0.1", "6.0.1" }, new bool[] { true, false, true })]
         [InlineData(new string[] { "6.0.0", "6.0.1", "7.0.0" }, new bool[] { true, true, false })]
         [InlineData(new string[] { "9.0.0", "9.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableWindows(string[] versions, bool[] allowed)
@@ -50,7 +50,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "1.0.0" }, new bool[] { false }, new string[] { "1.0.0" }, new bool[] { false })]
         [InlineData(new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false }, new string[] { "1.0.0", "1.0.1" }, new bool[] { true, false })]
         [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, true }, new string[] { "1.0.0", "1.1.0" }, new bool[] { false, false })]
-        [InlineData(new string[] { "3.0.0", "7.0.0" }, new bool[] { false, true }, new string[] { "1.0.0", "1.1.0", "1.0.1", "1.0.2", "1.1.3" }, new bool[] { true, true, true, false, false })]
+        [InlineData(new string[] { "3.0.0", "7.0.0" }, new bool[] { true, false }, new string[] { "1.0.0", "1.1.0", "1.0.1", "1.0.2", "1.1.3" }, new bool[] { true, true, true, false, false })]
         [InlineData(new string[] { "3.0.0", "5.0.0" }, new bool[] { true, false }, new string[] { "1.0.0", "1.1.0", "1.0.1", "5.0.0" }, new bool[] { true, false, false, false })]
         [InlineData(new string[] { "5.0.0", "5.0.1", "10.100.100" }, new bool[] { true, false, false }, new string[] { "5.0.0", "10.0.0" }, new bool[] { false, false })]
         [InlineData(new string[] { "5.0.0", "6.0.0", "6.0.1" }, new bool[] { true, true, false }, new string[] { "5.0.0" }, new bool[] { false })]
@@ -79,7 +79,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "5.0.0", "5.0.1", "10.0.1" }, new bool[] { true, false, false })]
-        [InlineData(new string[] { "5.0.0", "6.0.0", "6.0.1" }, new bool[] { true, true, false })]
+        [InlineData(new string[] { "5.0.0", "6.0.0", "6.0.1" }, new bool[] { false, true, true })]
         [InlineData(new string[] { "9.0.0", "9.0.1", "10.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableNonSdkVersionsWindows(string[] versions, bool[] allowed)
         {
@@ -179,7 +179,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [WindowsOnlyTheory]
         [InlineData(new string[] { }, new string[] { })]
         [InlineData(new string[] { "1.0.1", "1.0.0" }, new string[] { "", "None" })]
-        [InlineData(new string[] { "2.3.0", "2.1.800", "2.1.300" }, new string[] { "", " 2019", " 2017" })]
+        [InlineData(new string[] { "2.3.0", "2.1.800", "2.1.300" }, new string[] { "None", " 2019", " 2017" })]
         [InlineData(new string[] { "2.1.500", "2.1.400", "2.1.600" }, new string[] { " 2017", "None", " 2019" })]
         [InlineData(new string[] { "2.1.500", "10.0.1", "10.0.0" }, new string[] { " 2017", "UpperLimit", "UpperLimit" })]
         internal void TestGetListCommandUninstallableStringsWindows(string[] versions, string[] expectedStrings)


### PR DESCRIPTION
Bumps the maximum allowed version to 8.0.0, so that 7.0 and 7.0 previews can be managed.

Closes #230 