### PR TITLE
[dotnet-core-uninstall] Allow preview version removal

### DIFF
--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -596,7 +596,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above..
+        ///   Looks up a localized string similar to Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction..
         /// </summary>
         internal static string UninstallNotAllowedExceptionFormat {
             get {
@@ -641,7 +641,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot uninstall version {0} and above.
+        ///   Looks up a localized string similar to Cannot uninstall version {0} and above. Use —-force to remove.
         /// </summary>
         internal static string UpperLimitRequirement {
             get {

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -298,7 +298,7 @@ Do you want to continue? [y/n] </value>
     <value>Remove the specified .NET Core SDKs or Runtimes.</value>
   </data>
   <data name="UninstallNotAllowedExceptionFormat" xml:space="preserve">
-    <value>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</value>
+    <value>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</value>
   </data>
   <data name="WindowsRequiredBundleConfirmationPromptOutputFormat" xml:space="preserve">
     <value>
@@ -318,7 +318,7 @@ Uninstalling this item will cause Visual Studio to break.
     <value>Display .NET Core Uninstall Tool version information.</value>
   </data>
   <data name="UpperLimitRequirement" xml:space="preserve">
-    <value>Cannot uninstall version {0} and above</value>
+    <value>Cannot uninstall version {0} and above. Use —-force to remove</value>
   </data>
   <data name="WindowsRequirementExplanationString" xml:space="preserve">
     <value>Used by Visual Studio{0}. Specify individually or use —-force to remove</value>

--- a/src/dotnet-core-uninstall/Shared/Commands/CommandBundleFilter.cs
+++ b/src/dotnet-core-uninstall/Shared/Commands/CommandBundleFilter.cs
@@ -68,11 +68,12 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Commands
                     archSelection);
             }
 
-            if (parseResult.FindResultFor(CommandLineConfigs.ForceOption) == null)
+            if (!parseResult.ForceArgumentProvided())
             {
                 bundles = FilterRequiredBundles(allBundles, parseResult.CommandResult.Tokens).Intersect(bundles);
             }
-            if (bundles.Any(bundle => bundle.Version.SemVer >= VisualStudioSafeVersionsExtractor.UpperLimit))
+
+            if (bundles.Any(bundle => bundle.Version.SemVer >= VisualStudioSafeVersionsExtractor.UpperLimit) && !parseResult.ForceArgumentProvided())
             {
                 throw new UninstallationNotAllowedException();
             }

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -307,6 +307,11 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
                 archSelection;
         }
 
+        public static bool ForceArgumentProvided(this ParseResult parseResult)
+        {
+            return parseResult.FindResultFor(ForceOption) != null;
+        }
+
         public static VerbosityLevel GetVerbosityLevel(this CommandResult commandResult)
         {
             var optionResult = commandResult.FindResultFor(VerbosityOption);

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -322,8 +322,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallNotAllowedExceptionFormat">
-        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</source>
-        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above.</target>
+        <source>Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</source>
+        <target state="new">Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version {0} or above. Use --force to ignore this restriction.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallRuntimeOptionDescription">
@@ -357,8 +357,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UpperLimitRequirement">
-        <source>Cannot uninstall version {0} and above</source>
-        <target state="new">Cannot uninstall version {0} and above</target>
+        <source>Cannot uninstall version {0} and above. Use —-force to remove</source>
+        <target state="new">Cannot uninstall version {0} and above. Use —-force to remove</target>
         <note />
       </trans-unit>
       <trans-unit id="VerbosityLevelInvalidExceptionMessage">


### PR DESCRIPTION
Context: https://github.com/dotnet/cli-lab/issues/265

Updates the uninstall tool to ignore the upper version check and
uninstallation restriction when the `--force` parameter is provided.

Local testing output:

```console
% sudo dotnet artifacts/bin/dotnet-core-uninstall/Debug/net8.0/dotnet-core-uninstall.dll list                   

This tool cannot uninstall versions of the runtime or SDK that are installed using zip/scripts. The versions that can be uninstalled with this tool are:

.NET Core SDKs:
  9.0.100-preview.2.24157.14  (arm64)  [Cannot uninstall version 9.0.0 and above. Use —-force to remove]             
  8.0.101                     (arm64)  [Used by Visual Studio for Mac. Specify individually or use —-force to remove]
                                                                           

.NET Core Runtimes:
  9.0.0-preview.2.24128.5  (arm64)  [Used by Visual Studio for Mac or SDKs. Specify individually or use —-force to remove]
  9.0.0-preview.2.24128.5  (x64)                                                                                          
  9.0.0-preview.2.24128.4  (arm64)                                                                                        
  9.0.0-preview.2.24128.4  (x64)  
  8.0.1   (arm64)  [Used by Visual Studio for Mac or SDKs. Specify individually or use —-force to remove]
  8.0.1   (x64)                                                                                          

% sudo dotnet artifacts/bin/dotnet-core-uninstall/Debug/net8.0/dotnet-core-uninstall.dll remove --sdk 9.0.100-preview.2.24157.14
Uninstallation not allowed. This tool cannot uninstall .NET Core SDKs with version 9.0.0 or above. Use --force to ignore this restriction.

% sudo dotnet artifacts/bin/dotnet-core-uninstall/Debug/net8.0/dotnet-core-uninstall.dll remove --sdk 9.0.100-preview.2.24157.14 --force
The following items will be removed:
  Microsoft .NET Core SDK 9.0.100-preview.2.24157.14 (x64)

To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.

Do you want to continue? [y/n] y
Uninstalling: Microsoft .NET Core SDK 9.0.100-preview.2.24157.14 (x64).
```