### PR TITLE
Increase the upper limit to allow for .net 9 uninstall

### DIFF
--- a/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
+++ b/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
@@ -13,7 +13,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
     internal static class VisualStudioSafeVersionsExtractor
     {
         // The tool should not be used to uninstall any more recent versions of the sdk
-        public static readonly SemanticVersion UpperLimit = new SemanticVersion(9, 0, 0);
+        public static readonly SemanticVersion UpperLimit = new SemanticVersion(10, 0, 0);
 
         // Must keep one of each of these divisions to ensure Visual Studio works. 
         // Pairs are [inclusive, exclusive)
@@ -29,7 +29,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
             { (new SemanticVersion(5, 0, 100), new SemanticVersion(5, 0, 600)), string.Format(LocalizableStrings.WindowsRequirementExplanationString, " 2019") },
             { (new SemanticVersion(6, 0, 100), new SemanticVersion(6, 0, 500)), string.Format(LocalizableStrings.WindowsRequirementExplanationString, " 2022") },
             { (new SemanticVersion(7, 0, 100), new SemanticVersion(7, 0, 500)), string.Format(LocalizableStrings.WindowsRequirementExplanationString, " 2022") },
-            { (new SemanticVersion(8, 0, 100), UpperLimit), string.Format(LocalizableStrings.WindowsRequirementExplanationString, "") }
+            { (new SemanticVersion(8, 0, 100), new SemanticVersion(8, 0, 500)), string.Format(LocalizableStrings.WindowsRequirementExplanationString, " 2022") },
+            { (new SemanticVersion(9, 0, 100), UpperLimit), string.Format(LocalizableStrings.WindowsRequirementExplanationString, "") }
         };
 
         private static (IDictionary<IEnumerable<Bundle>, string>, IEnumerable<Bundle>) ApplyWindowsVersionDivisions(IEnumerable<Bundle> bundleList)

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -20,7 +20,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
 {
     public class CommandBundleFilterTests
     {
-        private static readonly string[] versions = { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "5.0.100", "6.0.100", "7.0.100", "8.0.100", "9.0.100", "10.10.10" };
+        private static readonly string[] versions = { "1.0.0", "1.0.1", "1.1.0", "2.1.0", "2.1.500", "2.1.600", "2.2.100", "2.2.200", "5.0.100", "6.0.100", "7.0.100", "8.0.100", "9.0.100", "10.0.100", "11.11.11" };
         private Dictionary<string, BundleArch> versionsWithArch = new Dictionary<string, BundleArch>
         {
             { "3.0.0", BundleArch.X64 },
@@ -131,10 +131,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
         }
 
         [Theory]
-        [InlineData("remove {0} 9.0.100")]
-        [InlineData("remove {0} 10.10.10")]
+        [InlineData("remove {0} 10.0.100")]
+        [InlineData("remove {0} 11.11.11")]
         [InlineData("remove {0} --all --force")]
-        [InlineData("remove {0} 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 5.0.100 7.0.100 10.10.10")]
+        [InlineData("remove {0} 1.0.0 1.0.1 1.1.0 2.1.0 2.1.500 2.1.600 2.2.100 2.2.200 5.0.100 7.0.100 11.11.11")]
         internal void TestUpperLimitAlwaysRequired(string command)
         {
             var sdkBundles = new List<Bundle<SdkVersion>>();

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -29,7 +29,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "3.0.100", "3.1.201", "5.0.100" }, new bool[] { true, false, false })]
         [InlineData(new string[] { "6.0.100", "6.0.101", "7.0.100" }, new bool[] { true, false, false })]
         [InlineData(new string[] { "7.0.100", "7.0.101", "8.0.100" }, new bool[] { true, false, false })]
-        [InlineData(new string[] { "9.0.100", "9.0.101", "10.100.100" }, new bool[] { false, false, false })]
+        [InlineData(new string[] { "8.0.100", "8.0.101", "9.0.100" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "10.0.100", "10.0.101", "11.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableWindows(string[] versions, bool[] allowed)
         {
             var bundles = new List<Bundle>();
@@ -52,7 +53,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "2.1.0", "1.0.1" }, new bool[] { false, true }, new string[] { "1.0.0", "1.1.0" }, new bool[] { false, false })]
         [InlineData(new string[] { "3.0.0", "7.0.100" }, new bool[] { true, false }, new string[] { "1.0.0", "1.1.0", "1.0.1", "1.0.2", "1.1.3" }, new bool[] { true, true, true, false, false })]
         [InlineData(new string[] { "3.0.0", "5.0.100" }, new bool[] { true, false }, new string[] { "1.0.0", "1.1.0", "1.0.1", "5.0.100" }, new bool[] { true, false, false, false })]
-        [InlineData(new string[] { "5.0.100", "5.0.101", "10.100.100" }, new bool[] { true, false, false }, new string[] { "5.0.100", "10.0.0" }, new bool[] { false, false })]
+        [InlineData(new string[] { "5.0.100", "5.0.101", "11.100.100" }, new bool[] { true, false, false }, new string[] { "5.0.100", "11.0.0" }, new bool[] { false, false })]
         [InlineData(new string[] { "5.0.100", "6.0.100", "6.0.101" }, new bool[] { true, true, false }, new string[] { "5.0.100" }, new bool[] { false })]
         internal void TestGetUninstallableMac(string[] sdkVersions, bool[] sdkAllowed, string[] runtimeVersions,  bool[] runtimeAllowed)
         {
@@ -80,7 +81,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "2.2.100", "2.2.200", "2.2.300" }, new bool[] { false, true, false })]
         [InlineData(new string[] { "5.0.100", "5.0.101", "10.0.1" }, new bool[] { true, false, false })]
         [InlineData(new string[] { "6.0.100", "7.0.100", "7.0.101" }, new bool[] { false, true, false })]
-        [InlineData(new string[] { "9.0.100", "9.0.101", "10.100.100" }, new bool[] { false, false, false })]
+        [InlineData(new string[] { "9.0.100", "9.0.101", "10.100.100" }, new bool[] { true, false, false })]
+        [InlineData(new string[] { "10.0.100", "10.0.101", "11.100.100" }, new bool[] { false, false, false })]
         internal void TestGetUninstallableNonSdkVersionsWindows(string[] versions, bool[] allowed)
         {
             var bundles = new List<Bundle>();
@@ -117,9 +119,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
             bundles = bundles.Concat(new List<Bundle>
             {
                 new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("1.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
-                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("10.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
+                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("11.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
                 new Bundle<HostingBundleVersion>(new HostingBundleVersion("1.0.0"), new BundleArch(), string.Empty, "HostingBundleVersion"),
-                new Bundle<HostingBundleVersion>(new HostingBundleVersion("10.0.0"), new BundleArch(), string.Empty, "HostingBundleVersion")
+                new Bundle<HostingBundleVersion>(new HostingBundleVersion("11.0.0"), new BundleArch(), string.Empty, "HostingBundleVersion")
             });
 
             var uninstallable = VisualStudioSafeVersionsExtractor.GetUninstallableBundles(bundles);
@@ -203,8 +205,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
         [InlineData(new string[] { "1.0.0", "1.0.1" }, new string[] { "None", "SDK" }, new string[] { "1.0.0", "1.0.1" }, new string[] { "None", "Runtime" })]
         [InlineData(new string[] { "2.1.0", "1.0.1" }, new string[] { "SDK", "None" }, new string[] { "2.0.0", "1.1.0" }, new string[] { "Runtime", "Runtime" })]
         [InlineData(new string[] { "3.0.100", "5.0.100" }, new string[] { "None", "SDK" }, new string[] { "1.0.0", "1.1.0", "1.0.1", "1.0.2", "1.1.3" }, new string[] { "None", "None", "None", "Runtime", "Runtime" })]
-        [InlineData(new string[] { "3.0.100", "5.0.100" }, new string[] { "None", "SDK" }, new string[] { "1.0.0", "1.1.0", "1.0.1", "9.0.100" }, new string[] { "None", "Runtime", "Runtime", "UpperLimit" })]
-        [InlineData(new string[] { "5.0.100", "5.0.101", "10.100.100" }, new string[] { "None", "SDK", "UpperLimit" }, new string[] { "5.0.100", "10.0.0" }, new string[] { "Runtime", "UpperLimit" })]
+        [InlineData(new string[] { "3.0.100", "5.0.100" }, new string[] { "None", "SDK" }, new string[] { "1.0.0", "1.1.0", "1.0.1", "10.0.100" }, new string[] { "None", "Runtime", "Runtime", "UpperLimit" })]
+        [InlineData(new string[] { "5.0.100", "5.0.101", "11.100.100" }, new string[] { "None", "SDK", "UpperLimit" }, new string[] { "5.0.100", "11.0.0" }, new string[] { "Runtime", "UpperLimit" })]
         internal void TestGetListCommandUninstallableStringsMac(string[] sdkVersions, string[] sdkExpected, string[] runtimeVersions, string[] runtimeExpected)
         {
             sdkExpected = sdkExpected.Select(s => s.Equals("UpperLimit") ? VisualStudioSafeVersionsExtractor.UpperLimit.ToNormalizedString() : s).ToArray();
@@ -228,9 +230,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
             bundles = bundles.Concat(new List<Bundle>
             {
                 new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("1.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
-                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("10.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
+                new Bundle<AspNetRuntimeVersion>(new AspNetRuntimeVersion("11.0.0"), new BundleArch(), string.Empty, "AspNetVersion"),
                 new Bundle<HostingBundleVersion>(new HostingBundleVersion("1.0.0"), new BundleArch(), string.Empty, "HostingBundleVersion"),
-                new Bundle<HostingBundleVersion>(new HostingBundleVersion("10.0.0"), new BundleArch(), string.Empty, "HostingBundleVersion")
+                new Bundle<HostingBundleVersion>(new HostingBundleVersion("11.0.0"), new BundleArch(), string.Empty, "HostingBundleVersion")
             });
 
             var strings = VisualStudioSafeVersionsExtractor.GetReasonRequiredStrings(bundles);


### PR DESCRIPTION
I updated the tests where anywhere I saw 9.0.100, I added a passing 9.0.100 if I could or just changed it to 10.0.100. I also switched any 10.0 entries to 11.0.