### PR TITLE
macOS: Show correct arm64 architecture

### DIFF
--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class LocalizableStrings {
@@ -291,7 +291,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Microsoft .NET Core {0} {1} (x64).
+        ///   Looks up a localized string similar to Microsoft .NET Core {0} {1} ({2}).
         /// </summary>
         internal static string MacOsBundleDisplayNameFormat {
             get {

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -229,7 +229,7 @@
     <value>Uninstalling: {0}.</value>
   </data>
   <data name="MacOsBundleDisplayNameFormat" xml:space="preserve">
-    <value>Microsoft .NET Core {0} {1} (x64)</value>
+    <value>Microsoft .NET Core {0} {1} ({2})</value>
   </data>
   <data name="CancelingMessage" xml:space="preserve">
     <value>Canceling: waiting for the current uninstall to complete.</value>

--- a/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
+++ b/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
@@ -26,7 +26,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
 
         public virtual IEnumerable<Bundle> GetAllInstalledBundles()
         {
-            // var nativeArch = IsMacx64Installation(DotNetInstallPath) ? BundleArch.X64 : BundleArch.Arm64;
             var sdks = GetInstalledBundles<SdkVersion>(DotNetSdkInstallPath(DotNetInstallPath));
             var runtimes = GetInstalledBundles<RuntimeVersion>(
                 DotNetRuntimeInstallPath(DotNetInstallPath),
@@ -38,13 +37,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
             {
                 sdks = sdks.Concat(GetInstalledBundles<SdkVersion>(DotNetSdkInstallPath(EmulatedDotNetInstallPath)));
                 runtimes = runtimes.Concat(GetInstalledBundles<RuntimeVersion>(
-                    DotNetRuntimeInstallPath(DotNetInstallPath),
-                    DotNetAspAllInstallPath(DotNetInstallPath),
-                    DotNetAspAppInstallPath(DotNetInstallPath),
-                    DotNetHostFxrInstallPath(DotNetInstallPath)));
+                    DotNetRuntimeInstallPath(EmulatedDotNetInstallPath),
+                    DotNetAspAllInstallPath(EmulatedDotNetInstallPath),
+                    DotNetAspAppInstallPath(EmulatedDotNetInstallPath),
+                    DotNetHostFxrInstallPath(EmulatedDotNetInstallPath)));
             }
 
-            return sdks.Concat(runtimes).ToList();
+            return [..sdks, ..runtimes];
         }
 
         private static bool IsMacx64Installation(string sdkVersionPath)

--- a/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
+++ b/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
@@ -51,7 +51,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
             try
             {
                 var rids = File.ReadAllText(Path.Combine(sdkVersionPath, "NETCoreSdkRuntimeIdentifierChain.txt"));
-                return !rids.Contains("arm64");
+                return !rids.Contains("osx-arm64");
             }
             catch
             {

--- a/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
+++ b/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
                     group.First().Version,
                     group.First().Arch,
                     GetUninstallCommand(group.Select(tuple => tuple.Path)),
-                    string.Format(LocalizableStrings.MacOsBundleDisplayNameFormat, bundleTypeString, group.First().Version.ToString(), group.First().Arch.ToString())));
+                    string.Format(LocalizableStrings.MacOsBundleDisplayNameFormat, bundleTypeString, group.First().Version.ToString(), group.First().Arch.ToString().ToLowerInvariant())));
         }
 
         private static IEnumerable<(TBundleVersion Version, string Path, BundleArch Arch)> GetInstalledVersionsAndUninstallCommands<TBundleVersion>(string path)

--- a/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
+++ b/src/dotnet-core-uninstall/MacOs/FileSystemExplorer.cs
@@ -77,7 +77,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.MacOs
                     group.First().Version,
                     group.First().Arch,
                     GetUninstallCommand(group.Select(tuple => tuple.Path)),
-                    string.Format(LocalizableStrings.MacOsBundleDisplayNameFormat, bundleTypeString, group.First().Version.ToString())));
+                    string.Format(LocalizableStrings.MacOsBundleDisplayNameFormat, bundleTypeString, group.First().Version.ToString(), group.First().Arch.ToString())));
         }
 
         private static IEnumerable<(TBundleVersion Version, string Path, BundleArch Arch)> GetInstalledVersionsAndUninstallCommands<TBundleVersion>(string path)

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -52,6 +52,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
         public static readonly string HostingBundleOptionName = "hosting-bundle";
         public static readonly string X64OptionName = "x64";
         public static readonly string X86OptionName = "x86";
+        public static readonly string Arm64OptionName = "arm64";
 
         public static readonly Option UninstallAllOption = new Option(
             "--all",
@@ -314,7 +315,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             var archSelection = new[]
             {
                 (OptionName: X64OptionName, Arch: BundleArch.X64),
-                (OptionName: X86OptionName, Arch: BundleArch.X86)
+                (OptionName: X86OptionName, Arch: BundleArch.X86),
+                (OptionName: Arm64OptionName, Arch: BundleArch.Arm64)
             }
             .Where(tuple => parseResult.ValueForOption<bool>($"--{tuple.OptionName}"))
             .Select(tuple => tuple.Arch)

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -151,8 +151,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
-        <source>Microsoft .NET Core {0} {1} (x64)</source>
-        <target state="new">Microsoft .NET Core {0} {1} (x64)</target>
+        <source>Microsoft .NET Core {0} {1} ({2})</source>
+        <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
         <note />
       </trans-unit>
       <trans-unit id="MacRequiredBundleConfirmationPromptOutputFormat">


### PR DESCRIPTION
Closes #297 #221 
When listing runtimes and sdk's on arm Macs, the architecture should be displayed as arm64 instead of x64.

Currently this is not figured out on a by version lookup, but based on the first directory on the sdk installs directory

`list`
![image](https://github.com/user-attachments/assets/5cc8db22-7f27-45e8-b593-f3043a829410)

`dry-run`
![image](https://github.com/user-attachments/assets/e0b4d46e-c1e4-49ee-a3ed-6e141632ec0a)

