### PR TITLE
Sign macOS build

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -145,11 +145,7 @@ extends:
                 --configuration $(_BuildConfig)
                 --prepareMachine
                 -p:RID=$(_RID)
-                -p:DotNetSignType=$(_SignType)
-                -p:SignCoreDotnetCoreUninstall=true
-                -p:TeamName=$(TeamName)
-                -p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-                -p:DotNetPublishUsingPipelines=true
+                --sign /p:DotNetSignType=real /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(Build.BuildNumber)
               displayName: Build
             - task: ArchiveFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -1,5 +1,5 @@
 variables:
-- name: _TeamName
+- name: TeamName
   value: DotNetCore
 - template: /eng/common/templates-official/variables/pool-providers.yml@self
 
@@ -91,7 +91,7 @@ extends:
               - name: _OfficialBuildArgs
                 value: /p:DotNetSignType=$(_SignType)
                       /p:SignCoreDotnetCoreUninstall=true
-                      /p:TeamName=$(_TeamName)
+                      /p:TeamName=$(TeamName)
                       /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
                       /p:DotNetPublishUsingPipelines=true
             # else
@@ -147,7 +147,7 @@ extends:
                 /p:RID=$(_RID)
                 /p:DotNetSignType=$(_SignType)
                 /p:SignCoreDotnetCoreUninstall=true
-                /p:TeamName=$(_TeamName)
+                /p:TeamName=$(TeamName)
                 /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
                 /p:DotNetPublishUsingPipelines=true
               displayName: Build

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -144,12 +144,12 @@ extends:
             - script: eng/common/cibuild.sh
                 --configuration $(_BuildConfig)
                 --prepareMachine
-                /p:RID=$(_RID)
-                /p:DotNetSignType=$(_SignType)
-                /p:SignCoreDotnetCoreUninstall=true
-                /p:TeamName=$(TeamName)
-                /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
-                /p:DotNetPublishUsingPipelines=true
+                -p:RID=$(_RID)
+                -p:DotNetSignType=$(_SignType)
+                -p:SignCoreDotnetCoreUninstall=true
+                -p:TeamName=$(TeamName)
+                -p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                -p:DotNetPublishUsingPipelines=true
               displayName: Build
             - task: ArchiveFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -142,10 +142,10 @@ extends:
             - checkout: self
               clean: true
             - script: eng/common/cibuild.sh
+                -sign 
                 --configuration $(_BuildConfig)
                 --prepareMachine
-                -p:RID=$(_RID)
-                --sign -p:DotNetSignType=real -p:TeamName=$(TeamName) -p:OfficialBuildId=$(Build.BuildNumber)
+                -p:RID=$(_RID) -p:DotNetSignType=real -p:TeamName=$(TeamName) -p:OfficialBuildId=$(Build.BuildNumber)
               displayName: Build
             - task: ArchiveFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -145,7 +145,7 @@ extends:
                 --configuration $(_BuildConfig)
                 --prepareMachine
                 -p:RID=$(_RID)
-                --sign /p:DotNetSignType=real /p:TeamName=$(_TeamName) /p:OfficialBuildId=$(Build.BuildNumber)
+                --sign /p:DotNetSignType=real /p:TeamName=$(TeamName) /p:OfficialBuildId=$(Build.BuildNumber)
               displayName: Build
             - task: ArchiveFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -117,7 +117,7 @@ extends:
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:
                 PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-                artifactName: 'drop-windows'
+                ArtifactName: 'drop-windows'
                 publishLocation: 'Container'
                 parallel: true
           - job: OSX_latest
@@ -164,7 +164,7 @@ extends:
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:
                 PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-                artifactName: 'drop-$(_RID)'
+                ArtifactName: 'drop-$(_RID)'
                 publishLocation: 'Container'
                 parallel: true
 

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -45,6 +45,7 @@ extends:
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:
           enableMicrobuild: true
+          enableMicrobuildForMacAndLinux: true
           enablePublishUsingPipelines: true
           enablePublishBuildArtifacts: true
           enablePublishTestResults: false
@@ -130,12 +131,12 @@ extends:
                 ARM64:
                   _RID: osx-arm64
                   _BuildConfig: Release
-                  _SignType: none
+                  _SignType: real
                   _DotNetPublishToBlobFeed: false
                 X64:
                   _RID: osx-x64
                   _BuildConfig: Release
-                  _SignType: none
+                  _SignType: real
                   _DotNetPublishToBlobFeed: false
             steps:
             - checkout: self
@@ -144,6 +145,11 @@ extends:
                 --configuration $(_BuildConfig)
                 --prepareMachine
                 /p:RID=$(_RID)
+                /p:DotNetSignType=$(_SignType)
+                /p:SignCoreDotnetCoreUninstall=true
+                /p:TeamName=$(_TeamName)
+                /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+                /p:DotNetPublishUsingPipelines=true
               displayName: Build
             - task: ArchiveFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -145,7 +145,7 @@ extends:
                 --configuration $(_BuildConfig)
                 --prepareMachine
                 -p:RID=$(_RID)
-                --sign /p:DotNetSignType=real /p:TeamName=$(TeamName) /p:OfficialBuildId=$(Build.BuildNumber)
+                --sign -p:DotNetSignType=real -p:TeamName=$(TeamName) -p:OfficialBuildId=$(Build.BuildNumber)
               displayName: Build
             - task: ArchiveFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
-    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/dotnet-core-uninstall" CertificateName="MacDeveloperHarden" />
-    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/dotnet-core-uninstall.pdb" CertificateName="MacDeveloperHarden" />
+    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/dotnet-core-uninstall" CertificateName="MicrosoftDotNet500" />
+    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/dotnet-core-uninstall.pdb" CertificateName="MicrosoftDotNet500" />
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,7 +5,7 @@
 
   <ItemGroup>
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
-    <FileSignInfo Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'" Include="$(ArtifactsDir)layout/**/dotnet-core-uninstall" CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'" Include="dotnet-core-uninstall" CertificateName="MicrosoftDotNet500" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,6 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
-    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*" CertificateName="MacDeveloperHarden" />
+    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/dotnet-core-uninstall" CertificateName="MacDeveloperHarden" />
+    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/dotnet-core-uninstall.pdb" CertificateName="MacDeveloperHarden" />
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,7 +5,6 @@
 
   <ItemGroup>
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
-    <FileSignInfo Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'" Include="dotnet-core-uninstall" CertificateName="MicrosoftDotNet500" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">
@@ -16,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
-    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*" />
+    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*">
+      <Authenticode>MacDeveloperHarden</Authenticode>
+      <StrongName>None</StrongName>
+      <Zip>true</Zip>
+    </ItemsToSign>
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
-  <FileSignInfo Include="dotnet-core-uninstall" CertificateName="MicrosoftDotNet500" />
-  <FileSignInfo Include="dotnet-core-uninstall.pdb" CertificateName="MicrosoftDotNet500" />
-    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*" CertificateName="MicrosoftDotNet500" />
+  <FileSignInfo Include="dotnet-core-uninstall" CertificateName="MacDeveloperHarden" />
+  <FileSignInfo Include="dotnet-core-uninstall.pdb" CertificateName="MacDeveloperHarden" />
+    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*" />
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -15,9 +15,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
-    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*">
-      <Authenticode>MacDeveloper</Authenticode>
-      <Zip>true</Zip>
-    </ItemsToSign>
+    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*" CertificateName="MacDeveloperHarden" />
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,7 +5,7 @@
 
   <ItemGroup>
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
-    <FileSignInfo Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'" Include="dotnet-core-uninstall" CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'" Include="$(ArtifactsDir)layout/**/dotnet-core-uninstall" CertificateName="MicrosoftDotNet500" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">
@@ -16,6 +16,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
-    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/dotnet-core-uninstall" />
+    <ItemsToSign Include="$(ArtifactsDir)layout/**/dotnet-core-uninstall" />
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -16,8 +16,7 @@
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
     <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*">
-      <Authenticode>MacDeveloperHarden</Authenticode>
-      <StrongName>None</StrongName>
+      <Authenticode>MacDeveloper</Authenticode>
       <Zip>true</Zip>
     </ItemsToSign>
   </ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -3,11 +3,8 @@
     <UseDotNetCertificate>true</UseDotNetCertificate>
   </PropertyGroup>
 
-  <ItemGroup>
-    <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(RID)' == 'win-x86'">
+    <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
     <ItemsToSign Include="$(ArtifactsDir)layout\**\dotnet-core-uninstall.dll;
       $(ArtifactsDir)layout\**\dotnet-core-uninstall.resources.dll;
       $(ArtifactsDir)layout\**\dotnet-core-uninstall.exe;
@@ -15,7 +12,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
-    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/dotnet-core-uninstall" CertificateName="MicrosoftDotNet500" />
-    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/dotnet-core-uninstall.pdb" CertificateName="MicrosoftDotNet500" />
+  <FileSignInfo Include="dotnet-core-uninstall" CertificateName="MicrosoftDotNet500" />
+  <FileSignInfo Include="dotnet-core-uninstall.pdb" CertificateName="MicrosoftDotNet500" />
+    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*" CertificateName="MicrosoftDotNet500" />
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'" Include="dotnet-core-uninstall" CertificateName="MicrosoftDotNet500" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -16,6 +16,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
-    <ItemsToSign Include="$(ArtifactsDir)layout/**/dotnet-core-uninstall" />
+    <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #300 

Uses 1ESPipelineTemplates EsrpCodesigning task to sign macOS builds.
Successfully generates signed binary artifacts for both x64 and arm64 on Mac.
See below output of  `codesign -dv` on a M1 Mac.

<img width="738" alt="image" src="https://github.com/user-attachments/assets/8257ce5c-7aaf-48f9-84b2-c2f2b321bcd8" />

![image](https://github.com/user-attachments/assets/f621f7a9-16f2-4091-9cca-9d6c30b3dac7)

