### PR TITLE
GetBundleVersion: Parse versions correctly to avoid duplicates or incomplete versions

### DIFF
--- a/src/dotnet-core-uninstall/Shared/Utils/Regexes.cs
+++ b/src/dotnet-core-uninstall/Shared/Utils/Regexes.cs
@@ -30,7 +30,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Utils
             $@"(?<{ArchGroupName}>\-?x64|x86)");
 
         private static readonly Regex _previewVersionSdkDisplayNameRegex = new Regex(
-            $@"(?<{PreviewGroupName}>\s?\-\s?((preview|alpha)\.?{_previewVersionNumberRegex.ToString()}|rc{_rcVersionNumberRegex.ToString()}))");
+            $@"(?<{PreviewGroupName}>.*((preview|alpha)[\.\-\s]?{_previewVersionNumberRegex.ToString()}|rc{_rcVersionNumberRegex.ToString()}))");
         private static readonly Regex _previewVersionSdkCachePathRegex = new Regex(
             $@"(?<{PreviewGroupName}>\-((preview|alpha)\.?{_previewVersionNumberRegex.ToString()}|rc{_rcVersionNumberRegex.ToString()}(\.\d+)?)\-(?<{BuildGroupName}>\d+))");
         private static readonly Regex _previewVersionRuntimeCachePathRegex = new Regex(
@@ -41,7 +41,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Utils
             $@"(?<{PreviewGroupName}>\-(preview{_previewVersionNumberRegex.ToString()}(\.{_buildNumberRegex.ToString()}\.\d+|\-(final|{_buildNumberRegex.ToString()}(\-\d+)?))|rc{_rcVersionNumberRegex.ToString()}\-final))");
 
         private static readonly string _sdkVersionBasicRegexFormat =
-            $@"(?<{VersionGroupName}>{_majorMinorRegex.ToString()}\.((?<{SdkMinorGroupName}>\d+)(?<{PatchGroupName}>\d{{{{2}}}})|(?<{PatchGroupName}>\d{{{{1,2}}}}))({{0}})?)";
+            $@"(?<{VersionGroupName}>{_majorMinorRegex.ToString()}\.((?<{SdkMinorGroupName}>\d+)(?<{PatchGroupName}>\d{{{{0,2}}}}))({{0}})?)";
         private static readonly string _notCapturedRuntimeVersionBasicRegexFormat =
             $@"{_majorMinorRegex.ToString()}\.(?<{PatchGroupName}>\d+)({{0}})?";
         private static readonly string _runtimeVersionBasicRegexFormat =
@@ -76,7 +76,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Utils
 
         public static readonly Regex VersionDisplayNameRegex = new Regex(string.Format(
             _sdkVersionBasicRegexFormat,
-            _previewVersionSdkDisplayNameRegex.ToString()));
+            _previewVersionSdkDisplayNameRegex.ToString()), RegexOptions.IgnoreCase);
         public static readonly Regex BundleMajorMinorRegex = new Regex(
             $@"^{_majorMinorRegex.ToString()}$");
         public static readonly Regex BundleCachePathRegex = new Regex(

--- a/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
+++ b/src/dotnet-core-uninstall/Shared/VSVersioning/VisualStudioSafeVersionsExtractor.cs
@@ -113,13 +113,17 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.VSVersioning
             foreach (var division in bundlesByDivisions)
             {
                 var requiredBundle = division.Key.Max();
-                requirementStringResults = requirementStringResults.Append((requiredBundle, division.Value));
-                requirementStringResults = requirementStringResults.Concat(division.Key
-                    .Where(bundle => !bundle.Equals(requiredBundle))
-                    .Select(bundle => (bundle, string.Empty)));
+                requirementStringResults = requirementStringResults.Concat([
+                    (requiredBundle, division.Value),
+                    ..division.Key
+                        .Where(bundle => !bundle.Equals(requiredBundle))
+                        .Select(bundle => (bundle, string.Empty))
+                ]);
             }
 
             return requirementStringResults
+                .GroupBy(pair => pair.bundle)
+                .Select(group => group.First()) // Remove duplicates
                 .OrderByDescending(pair => pair.bundle.DisplayName)
                 .ToDictionary(i => i.bundle, i => i.Item2);
         }

--- a/src/dotnet-core-uninstall/Windows/RegistryQuery.cs
+++ b/src/dotnet-core-uninstall/Windows/RegistryQuery.cs
@@ -130,12 +130,13 @@ namespace Microsoft.DotNet.Tools.Uninstall.Windows
                     return new AspNetRuntimeVersion(versionString);
                 }
                 else if ((displayName.IndexOf(".NET Core SDK", StringComparison.OrdinalIgnoreCase) >= 0) ||
-                        (displayName.IndexOf("Microsoft .NET SDK", StringComparison.OrdinalIgnoreCase) >= 0) ||
-                        uninstallString.IndexOf("dotnet-dev-win") >= 0)
+                    (displayName.IndexOf("Microsoft .NET SDK", StringComparison.OrdinalIgnoreCase) >= 0) ||
+                    uninstallString.IndexOf("dotnet-dev-win") >= 0)
                 {
                     return new SdkVersion(versionString);
                 }
-                else if (displayName.IndexOf(".NET Core Runtime", StringComparison.OrdinalIgnoreCase) >= 0 || Regex.IsMatch(displayName, @".*\.NET Core.*Runtime") ||
+                else if (displayName.IndexOf(".NET Core Runtime", StringComparison.OrdinalIgnoreCase) >= 0 || 
+                    Regex.IsMatch(displayName, @".*\.NET Core.*Runtime") ||
                     displayName.IndexOf(".NET Runtime", StringComparison.OrdinalIgnoreCase) >= 0)
                 {
                     return new RuntimeVersion(versionString);


### PR DESCRIPTION
Fixes #264
Fixes #232 
Fixes #218 
Fixes #285 

When generating a dictionary for the reason required strings (i.e. `Used by Visual Studio`), pairs could be duplicate bundles, which would lead to unhandled exceptions when converting to a dictionary
