### PR TITLE
Refactor macOS build pipeline

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -16,6 +16,13 @@ pr:
     include:
     - '*'
 
+parameters:
+- name: MacOSArchitectures
+  type: object
+  default:
+  - arm64
+  - x64
+
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -120,16 +127,16 @@ extends:
                 publishLocation: 'Container'
                 parallel: true
 
-          - ${{ each _RID in ['x64', 'arm64'] }}:
-            - job: OSX_latest_${{ _RID }}
-              displayName: 'Mac OS (${{ _RID }})'
+          - ${{ each arch in parameters.MacOSArchitectures }}:
+            - job: OSX_latest_${{ arch }}
+              displayName: 'Mac OS (${{ arch }})'
               pool:
                 name: Azure Pipelines
                 image: 'macOS-latest'
                 os: macOS
               variables:
               - name: _RID
-                value: osx-${{ _RID }})'
+                value: osx-${{ arch }})'
               - name: _BuildConfig
                 value: Release
               - name: _SignType
@@ -157,6 +164,6 @@ extends:
                 condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
                 inputs:
                   PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-                  artifactName: 'drop-osx-${{ _RID }})'
+                  artifactName: 'drop-osx-${{ arch }}'
                   publishLocation: 'Container'
                   parallel: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -127,16 +127,16 @@ extends:
               os: macOS
             strategy:
               matrix:
-                - ARM64:
-                    _RID: osx-arm64
-                    _BuildConfig: Release
-                    _SignType: none
-                    _DotNetPublishToBlobFeed: false
-                  X64:
-                    _RID: osx-x64
-                    _BuildConfig: Release
-                    _SignType: none
-                    _DotNetPublishToBlobFeed: false
+                ARM64:
+                  _RID: osx-arm64
+                  _BuildConfig: Release
+                  _SignType: none
+                  _DotNetPublishToBlobFeed: false
+                X64:
+                  _RID: osx-x64
+                  _BuildConfig: Release
+                  _SignType: none
+                  _DotNetPublishToBlobFeed: false
             steps:
             - checkout: self
               clean: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -158,7 +158,7 @@ extends:
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:
                 PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-                artifactName: 'drop-osx'
+                artifactName: 'drop-$(_RID)'
                 publishLocation: 'Container'
                 parallel: true
 

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -121,15 +121,15 @@ extends:
                 parallel: true
 
           - {{ each _RID in ['x64', 'arm64'] }}
-            - job: OSX_latest_${_RID}
-              displayName: 'Mac OS (${_RID})'
+            - job: OSX_latest_arm64
+              displayName: 'Mac OS (arm64)'
               pool:
                 name: Azure Pipelines
                 image: 'macOS-latest'
                 os: macOS
               variables:
               - name: _RID
-                value: osx-${_RID}
+                value: osx-arm64
               - name: _BuildConfig
                 value: Release
               - name: _SignType
@@ -157,6 +157,6 @@ extends:
                 condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
                 inputs:
                   PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-                  artifactName: 'drop-osx-${_RID}'
+                  artifactName: 'drop-osx-arm64'
                   publishLocation: 'Container'
                   parallel: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -120,7 +120,7 @@ extends:
                 publishLocation: 'Container'
                 parallel: true
 
-          - {{ each _RID in ['x64', 'arm64'] }}:
+          - ${{ each _RID in ['x64', 'arm64'] }}:
             - job: OSX_latest_${{ _RID }}
               displayName: 'Mac OS (${{ _RID }})'
               pool:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -120,16 +120,16 @@ extends:
                 publishLocation: 'Container'
                 parallel: true
 
-          - {{ each _RID in ['x64', 'arm64'] }}
-            - job: OSX_latest_arm64
-              displayName: 'Mac OS (arm64)'
+          - {{ each _RID in ['x64', 'arm64'] }}:
+            - job: OSX_latest_${{ _RID }}
+              displayName: 'Mac OS (${{ _RID }})'
               pool:
                 name: Azure Pipelines
                 image: 'macOS-latest'
                 os: macOS
               variables:
               - name: _RID
-                value: osx-arm64
+                value: osx-${{ _RID }})'
               - name: _BuildConfig
                 value: Release
               - name: _SignType
@@ -157,6 +157,6 @@ extends:
                 condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
                 inputs:
                   PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-                  artifactName: 'drop-osx-arm64'
+                  artifactName: 'drop-osx-${{ _RID }})'
                   publishLocation: 'Container'
                   parallel: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -16,13 +16,6 @@ pr:
     include:
     - '*'
 
-parameters:
-- name: MacOSArchitectures
-  type: object
-  default:
-  - arm64
-  - x64
-
 resources:
   repositories:
   - repository: 1ESPipelineTemplates
@@ -126,44 +119,46 @@ extends:
                 artifactName: 'drop-windows'
                 publishLocation: 'Container'
                 parallel: true
+          - job: OSX_latest
+            displayName: 'Mac OS'
+            pool:
+              name: Azure Pipelines
+              image: 'macOS-latest'
+              os: macOS
+            strategy:
+              matrix:
+                - ARM64:
+                    _RID: osx-arm64
+                    _BuildConfig: Release
+                    _SignType: none
+                    _DotNetPublishToBlobFeed: false
+                  X64:
+                    _RID: osx-x64
+                    _BuildConfig: Release
+                    _SignType: none
+                    _DotNetPublishToBlobFeed: false
+            steps:
+            - checkout: self
+              clean: true
+            - script: eng/common/cibuild.sh
+                --configuration $(_BuildConfig)
+                --prepareMachine
+                /p:RID=$(_RID)
+              displayName: Build
+            - task: ArchiveFiles@2
+              condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+              inputs:
+                rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
+                includeRootFolder: false
+                archiveType: 'tar'
+                tarCompression: 'gz'
+                archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
+                replaceExistingArchive: true
+            - task: 1ES.PublishBuildArtifacts@1
+              condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+              inputs:
+                PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+                artifactName: 'drop-osx'
+                publishLocation: 'Container'
+                parallel: true
 
-          - ${{ each arch in parameters.MacOSArchitectures }}:
-            - job: OSX_latest_${{ arch }}
-              displayName: 'Mac OS (${{ arch }})'
-              pool:
-                name: Azure Pipelines
-                image: 'macOS-latest'
-                os: macOS
-              variables:
-              - name: _RID
-                value: osx-${{ arch }})'
-              - name: _BuildConfig
-                value: Release
-              - name: _SignType
-                value: none
-              - name: _DotNetPublishToBlobFeed
-                value: false
-              steps:
-              - checkout: self
-                clean: true
-              - script: eng/common/cibuild.sh
-                  --configuration $(_BuildConfig)
-                  --prepareMachine
-                  /p:RID=$(_RID)
-                displayName: Build
-              - task: ArchiveFiles@2
-                condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-                inputs:
-                  rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
-                  includeRootFolder: false
-                  archiveType: 'tar'
-                  tarCompression: 'gz'
-                  archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
-                  replaceExistingArchive: true
-              - task: 1ES.PublishBuildArtifacts@1
-                condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-                inputs:
-                  PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-                  artifactName: 'drop-osx-${{ arch }}'
-                  publishLocation: 'Container'
-                  parallel: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -119,82 +119,44 @@ extends:
                 artifactName: 'drop-windows'
                 publishLocation: 'Container'
                 parallel: true
-          - job: OSX_latest_x64
-            displayName: 'Mac OS (x64)'
-            pool:
-              name: Azure Pipelines
-              image: 'macOS-latest'
-              os: macOS
-            variables:
-            - name: _RID
-              value: osx-x64
-            - name: _BuildConfig
-              value: Release
-            - name: _SignType
-              value: none
-            - name: _DotNetPublishToBlobFeed
-              value: false
-            steps:
-            - checkout: self
-              clean: true
-            - script: eng/common/cibuild.sh
-                --configuration $(_BuildConfig)
-                --prepareMachine
-                /p:RID=$(_RID)
-              displayName: Build
-            - task: ArchiveFiles@2
-              condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-              inputs:
-                rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
-                includeRootFolder: false
-                archiveType: 'tar'
-                tarCompression: 'gz'
-                archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
-                replaceExistingArchive: true
-            - task: 1ES.PublishBuildArtifacts@1
-              condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-              inputs:
-                PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-                artifactName: 'drop-osx'
-                publishLocation: 'Container'
-                parallel: true
-          - job: OSX_latest_arm64
-            displayName: 'Mac OS (arm64)'
-            pool:
-              name: Azure Pipelines
-              image: 'macOS-latest'
-              os: macOS
-            variables:
-            - name: _RID
-              value: osx-arm64
-            - name: _BuildConfig
-              value: Release
-            - name: _SignType
-              value: none
-            - name: _DotNetPublishToBlobFeed
-              value: false
-            steps:
-            - checkout: self
-              clean: true
-            - script: eng/common/cibuild.sh
-                --configuration $(_BuildConfig)
-                --prepareMachine
-                /p:RID=$(_RID)
-              displayName: Build
-            - task: ArchiveFiles@2
-              condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-              inputs:
-                rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
-                includeRootFolder: false
-                archiveType: 'tar'
-                tarCompression: 'gz'
-                archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
-                replaceExistingArchive: true
-            - task: 1ES.PublishBuildArtifacts@1
-              condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-              inputs:
-                PathtoPublish: '$(Build.ArtifactStagingDirectory)'
-                artifactName: 'drop-osx'
-                publishLocation: 'Container'
-                parallel: true
 
+          - {{ each _RID in ['x64', 'arm64'] }}
+            - job: OSX_latest_${_RID}
+              displayName: 'Mac OS (${_RID})'
+              pool:
+                name: Azure Pipelines
+                image: 'macOS-latest'
+                os: macOS
+              variables:
+              - name: _RID
+                value: osx-${_RID}
+              - name: _BuildConfig
+                value: Release
+              - name: _SignType
+                value: none
+              - name: _DotNetPublishToBlobFeed
+                value: false
+              steps:
+              - checkout: self
+                clean: true
+              - script: eng/common/cibuild.sh
+                  --configuration $(_BuildConfig)
+                  --prepareMachine
+                  /p:RID=$(_RID)
+                displayName: Build
+              - task: ArchiveFiles@2
+                condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+                inputs:
+                  rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
+                  includeRootFolder: false
+                  archiveType: 'tar'
+                  tarCompression: 'gz'
+                  archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
+                  replaceExistingArchive: true
+              - task: 1ES.PublishBuildArtifacts@1
+                condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+                inputs:
+                  PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+                  artifactName: 'drop-osx-${_RID}'
+                  publishLocation: 'Container'
+                  parallel: true

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -99,48 +99,48 @@ stages:
             publishLocation: 'Container'
             parallel: true
       - {{ each _RID in ['x64', 'arm64'] }}
-            - job: OSX_latest_${_RID}
-              displayName: 'Mac OS (${_RID})'
-              pool:
-                vmImage: 'macOS-latest'
-              strategy:
-                matrix:
-                  ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-                    Debug:
-                      _BuildConfig: Debug
-                      _SignType: none
-                      _DotNetPublishToBlobFeed : false
-                  Release:
-                    _BuildConfig: Release
-                    _SignType: none
-                    _DotNetPublishToBlobFeed : false
-              variables:
-              - name: _RID
-                value: osx-${_RID}
-              steps:
-              - checkout: self
-                clean: true
-              - script: eng/common/cibuild.sh
-                  --configuration $(_BuildConfig)
-                  --prepareMachine
-                  /p:RID=$(_RID)
-                displayName: Build
-              - task: ArchiveFiles@2
-                condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-                inputs:
-                  rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
-                  includeRootFolder: false
-                  archiveType: 'tar'
-                  tarCompression: 'gz'
-                  archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
-                  replaceExistingArchive: true
-              - task: PublishBuildArtifacts@1
-                condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-                inputs:
-                  pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-                  artifactName: 'drop-osx-${_RID}'
-                  publishLocation: 'Container'
-                  parallel: true
+        - job: OSX_latest_${_RID}
+          displayName: 'Mac OS (${_RID})'
+          pool:
+            vmImage: 'macOS-latest'
+          strategy:
+            matrix:
+              ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+                Debug:
+                  _BuildConfig: Debug
+                  _SignType: none
+                  _DotNetPublishToBlobFeed : false
+              Release:
+                _BuildConfig: Release
+                _SignType: none
+                _DotNetPublishToBlobFeed : false
+          variables:
+          - name: _RID
+            value: osx-${_RID}
+          steps:
+          - checkout: self
+            clean: true
+          - script: eng/common/cibuild.sh
+              --configuration $(_BuildConfig)
+              --prepareMachine
+              /p:RID=$(_RID)
+            displayName: Build
+          - task: ArchiveFiles@2
+            condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+            inputs:
+              rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
+              includeRootFolder: false
+              archiveType: 'tar'
+              tarCompression: 'gz'
+              archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
+              replaceExistingArchive: true
+          - task: PublishBuildArtifacts@1
+            condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+            inputs:
+              pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+              artifactName: 'drop-osx-${_RID}'
+              publishLocation: 'Container'
+              parallel: true
 
 - ${{ if eq(variables._RunAsInternal, True) }}:
   - template: eng\common\templates\post-build\post-build.yml

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -146,7 +146,7 @@ stages:
           condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
           inputs:
             pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-            artifactName: 'drop-osx'
+            artifactName: 'drop-$(_RID)'
             publishLocation: 'Container'
             parallel: true
 

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -98,9 +98,9 @@ stages:
             artifactName: 'drop-windows'
             publishLocation: 'Container'
             parallel: true
-      - {{ each _RID in ['x64', 'arm64'] }}
-        - job: OSX_latest_${_RID}
-          displayName: 'Mac OS (${_RID})'
+      - {{ each _RID in ['x64', 'arm64'] }}:
+        - job: OSX_latest_${{ _RID }}
+          displayName: 'Mac OS (${{ _RID }})'
           pool:
             vmImage: 'macOS-latest'
           strategy:
@@ -116,7 +116,7 @@ stages:
                 _DotNetPublishToBlobFeed : false
           variables:
           - name: _RID
-            value: osx-${_RID}
+            value: osx-${{ _RID }}
           steps:
           - checkout: self
             clean: true
@@ -138,7 +138,7 @@ stages:
             condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
             inputs:
               pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-              artifactName: 'drop-osx-${_RID}'
+              artifactName: 'drop-osx-${{ _RID }}'
               publishLocation: 'Container'
               parallel: true
 

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -15,6 +15,13 @@ pr:
     include:
     - '*'
 
+parameters:
+- name: MacOSArchitectures
+  type: object
+  default:
+  - arm64
+  - x64
+
 stages:
 - stage: build
   displayName: Build
@@ -98,9 +105,9 @@ stages:
             artifactName: 'drop-windows'
             publishLocation: 'Container'
             parallel: true
-      - {{ each _RID in ['x64', 'arm64'] }}:
-        - job: OSX_latest_${{ _RID }}
-          displayName: 'Mac OS (${{ _RID }})'
+      - ${{ each arch in parameters.MacOSArchitectures }}:
+        - job: OSX_latest_${{ arch }}
+          displayName: 'Mac OS (${{ arch }})'
           pool:
             vmImage: 'macOS-latest'
           strategy:
@@ -116,7 +123,7 @@ stages:
                 _DotNetPublishToBlobFeed : false
           variables:
           - name: _RID
-            value: osx-${{ _RID }}
+            value: osx-${{ arch }}
           steps:
           - checkout: self
             clean: true
@@ -138,7 +145,7 @@ stages:
             condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
             inputs:
               pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-              artifactName: 'drop-osx-${{ _RID }}'
+              artifactName: 'drop-osx-${{ arch }}'
               publishLocation: 'Container'
               parallel: true
 

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -98,90 +98,49 @@ stages:
             artifactName: 'drop-windows'
             publishLocation: 'Container'
             parallel: true
-      - job: OSX_latest_x64
-        displayName: 'Mac OS (x64)'
-        pool:
-          vmImage: 'macOS-latest'
-        strategy:
-          matrix:
-            ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-              Debug:
-                _BuildConfig: Debug
-                _SignType: none
-                _DotNetPublishToBlobFeed : false
-            Release:
-              _BuildConfig: Release
-              _SignType: none
-              _DotNetPublishToBlobFeed : false
-        variables:
-        - name: _RID
-          value: osx-x64
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng/common/cibuild.sh
-            --configuration $(_BuildConfig)
-            --prepareMachine
-            /p:RID=$(_RID)
-          displayName: Build
-        - task: ArchiveFiles@2
-          condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-          inputs:
-            rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
-            includeRootFolder: false
-            archiveType: 'tar'
-            tarCompression: 'gz'
-            archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
-            replaceExistingArchive: true
-        - task: PublishBuildArtifacts@1
-          condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-          inputs:
-            pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-            artifactName: 'drop-osx'
-            publishLocation: 'Container'
-            parallel: true
-      - job: OSX_latest_arm64
-        displayName: 'Mac OS (arm64)'
-        pool:
-          vmImage: 'macOS-latest'
-        strategy:
-          matrix:
-            ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-              Debug:
-                _BuildConfig: Debug
-                _SignType: none
-                _DotNetPublishToBlobFeed : false
-            Release:
-              _BuildConfig: Release
-              _SignType: none
-              _DotNetPublishToBlobFeed : false
-        variables:
-        - name: _RID
-          value: osx-arm64
-        steps:
-        - checkout: self
-          clean: true
-        - script: eng/common/cibuild.sh
-            --configuration $(_BuildConfig)
-            --prepareMachine
-            /p:RID=$(_RID)
-          displayName: Build
-        - task: ArchiveFiles@2
-          condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-          inputs:
-            rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
-            includeRootFolder: false
-            archiveType: 'tar'
-            tarCompression: 'gz'
-            archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
-            replaceExistingArchive: true
-        - task: PublishBuildArtifacts@1
-          condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-          inputs:
-            pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-            artifactName: 'drop-osx'
-            publishLocation: 'Container'
-            parallel: true
+      - {{ each _RID in ['x64', 'arm64'] }}
+            - job: OSX_latest_${_RID}
+              displayName: 'Mac OS (${_RID})'
+              pool:
+                vmImage: 'macOS-latest'
+              strategy:
+                matrix:
+                  ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+                    Debug:
+                      _BuildConfig: Debug
+                      _SignType: none
+                      _DotNetPublishToBlobFeed : false
+                  Release:
+                    _BuildConfig: Release
+                    _SignType: none
+                    _DotNetPublishToBlobFeed : false
+              variables:
+              - name: _RID
+                value: osx-${_RID}
+              steps:
+              - checkout: self
+                clean: true
+              - script: eng/common/cibuild.sh
+                  --configuration $(_BuildConfig)
+                  --prepareMachine
+                  /p:RID=$(_RID)
+                displayName: Build
+              - task: ArchiveFiles@2
+                condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+                inputs:
+                  rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
+                  includeRootFolder: false
+                  archiveType: 'tar'
+                  tarCompression: 'gz'
+                  archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
+                  replaceExistingArchive: true
+              - task: PublishBuildArtifacts@1
+                condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+                inputs:
+                  pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+                  artifactName: 'drop-osx-${_RID}'
+                  publishLocation: 'Container'
+                  parallel: true
 
 - ${{ if eq(variables._RunAsInternal, True) }}:
   - template: eng\common\templates\post-build\post-build.yml

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -15,13 +15,6 @@ pr:
     include:
     - '*'
 
-parameters:
-- name: MacOSArchitectures
-  type: object
-  default:
-  - arm64
-  - x64
-
 stages:
 - stage: build
   displayName: Build
@@ -105,49 +98,57 @@ stages:
             artifactName: 'drop-windows'
             publishLocation: 'Container'
             parallel: true
-      - ${{ each arch in parameters.MacOSArchitectures }}:
-        - job: OSX_latest_${{ arch }}
-          displayName: 'Mac OS (${{ arch }})'
-          pool:
-            vmImage: 'macOS-latest'
-          strategy:
-            matrix:
-              ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
-                Debug:
-                  _BuildConfig: Debug
-                  _SignType: none
-                  _DotNetPublishToBlobFeed : false
-              Release:
-                _BuildConfig: Release
+      - job: OSX_latest
+        displayName: 'Mac OS'
+        pool:
+          vmImage: 'macOS-latest'
+        strategy:
+          matrix:
+            ${{ if in(variables['Build.Reason'], 'PullRequest') }}:
+              Debug_arm64:
+                _BuildConfig: Debug
                 _SignType: none
                 _DotNetPublishToBlobFeed : false
-          variables:
-          - name: _RID
-            value: osx-${{ arch }}
-          steps:
-          - checkout: self
-            clean: true
-          - script: eng/common/cibuild.sh
-              --configuration $(_BuildConfig)
-              --prepareMachine
-              /p:RID=$(_RID)
-            displayName: Build
-          - task: ArchiveFiles@2
-            condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-            inputs:
-              rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
-              includeRootFolder: false
-              archiveType: 'tar'
-              tarCompression: 'gz'
-              archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
-              replaceExistingArchive: true
-          - task: PublishBuildArtifacts@1
-            condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
-            inputs:
-              pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-              artifactName: 'drop-osx-${{ arch }}'
-              publishLocation: 'Container'
-              parallel: true
+                _RID: osx-arm64
+              Debug_x64:
+                _BuildConfig: Debug
+                _SignType: none
+                _DotNetPublishToBlobFeed : false
+                _RID: osx-x64
+            Release_arm64:
+              _BuildConfig: Release
+              _SignType: none
+              _DotNetPublishToBlobFeed : false
+              _RID: osx-arm64
+            Release_x64:
+              _BuildConfig: Release
+              _SignType: none
+              _DotNetPublishToBlobFeed : false
+              _RID: osx-x64
+        steps:
+        - checkout: self
+          clean: true
+        - script: eng/common/cibuild.sh
+            --configuration $(_BuildConfig)
+            --prepareMachine
+            /p:RID=$(_RID)
+          displayName: Build
+        - task: ArchiveFiles@2
+          condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+          inputs:
+            rootFolderOrFile: 'artifacts/layout/dotnet-core-uninstall/'
+            includeRootFolder: false
+            archiveType: 'tar'
+            tarCompression: 'gz'
+            archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
+            replaceExistingArchive: true
+        - task: PublishBuildArtifacts@1
+          condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
+          inputs:
+            pathtoPublish: '$(Build.ArtifactStagingDirectory)'
+            artifactName: 'drop-osx'
+            publishLocation: 'Container'
+            parallel: true
 
 - ${{ if eq(variables._RunAsInternal, True) }}:
   - template: eng\common\templates\post-build\post-build.yml


### PR DESCRIPTION
Simplifies the workflow of macOS builds to make it easier to extend afterwards (e.g., adding signing, notarization, etc)