### PR TITLE
Fix Windows Signing

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,10 +5,8 @@
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">
     <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
-    <ItemsToSign Include="$(ArtifactsDir)layout\**\dotnet-core-uninstall.dll;
-      $(ArtifactsDir)layout\**\dotnet-core-uninstall.resources.dll;
-      $(ArtifactsDir)layout\**\dotnet-core-uninstall.exe;
-      $(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi" />
+    <ItemsToSign Include="$(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi;
+      $(ArtifactsDir)packages\**\dotnet-core-uninstall*.wixpdb" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,7 +5,10 @@
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">
     <FileExtensionSignInfo Include=".msi;.wixpdb" CertificateName="MicrosoftDotNet500" />
-    <ItemsToSign Include="$(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi;
+    <ItemsToSign Include="$(ArtifactsDir)layout\**\dotnet-core-uninstall.dll;
+      $(ArtifactsDir)layout\**\dotnet-core-uninstall.resources.dll;
+      $(ArtifactsDir)layout\**\dotnet-core-uninstall.exe;
+      $(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi;
       $(ArtifactsDir)packages\**\dotnet-core-uninstall*.wixpdb" />
   </ItemGroup>
 

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">
-    <FileExtensionSignInfo Include=".msi" CertificateName="MicrosoftDotNet500" />
+    <FileExtensionSignInfo Include=".msi;.wixpdb" CertificateName="MicrosoftDotNet500" />
     <ItemsToSign Include="$(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi;
       $(ArtifactsDir)packages\**\dotnet-core-uninstall*.wixpdb" />
   </ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,11 +5,8 @@
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">
     <FileExtensionSignInfo Include=".msi;.wixpdb" CertificateName="MicrosoftDotNet500" />
-    <ItemsToSign Include="$(ArtifactsDir)layout\**\dotnet-core-uninstall.dll;
-      $(ArtifactsDir)layout\**\dotnet-core-uninstall.resources.dll;
-      $(ArtifactsDir)layout\**\dotnet-core-uninstall.exe;
-      $(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi;
-      $(ArtifactsDir)packages\**\dotnet-core-uninstall*.wixpdb" />
+    <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**\*.wixpack.zip;
+      $(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi;" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -12,8 +12,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
-  <FileSignInfo Include="dotnet-core-uninstall" CertificateName="MacDeveloperHarden" />
-  <FileSignInfo Include="dotnet-core-uninstall.pdb" CertificateName="MacDeveloperHarden" />
+    <FileSignInfo Include="dotnet-core-uninstall" CertificateName="MacDeveloperHarden" />
+    <FileSignInfo Include="dotnet-core-uninstall.pdb" CertificateName="MacDeveloperHarden" />
     <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*" />
   </ItemGroup>
 </Project>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <ProjectReference Include="..\dotnet-core-uninstall\dotnet-core-uninstall.csproj" />
   </ItemGroup>
-  
+
   <Import Condition="'$(RID)' == 'win-x86'" Project="targets\Versions.targets" />
   <Import Condition="'$(RID)' == 'win-x86'" Project="targets\BuildCoreSdkTasks.targets" />
   <Import Condition="'$(RID)' == 'win-x86'" Project="targets\GetRuntimeInformation.targets" />
@@ -18,5 +18,6 @@
   <Import Condition="'$(RID)' == 'win-x86'" Project="targets\FileExtensions.targets" />
   <Import Condition="'$(RID)' == 'win-x86'" Project="targets\GenerateMSIs.targets" />
   <Target Condition="'$(RID)' == 'win-x86'" Name="GenerateMSIs" AfterTargets="Build" DependsOnTargets="GenerateLayout;GenerateDotnetCoreUninstallMsi" />
+  <Target Condition="'$(RID)' == 'win-x86'" Name="SignBeforMSIs" BeforeTargets="GenerateDotnetCoreUninstallMsi" DependsOnTargets="SignFiles" />
 
 </Project>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\dotnet-core-uninstall\dotnet-core-uninstall.csproj" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25124.4"/>
   </ItemGroup>
 
   <Import Condition="'$(RID)' == 'win-x86'" Project="targets\Versions.targets" />

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -18,6 +18,4 @@
   <Import Condition="'$(RID)' == 'win-x86'" Project="targets\FileExtensions.targets" />
   <Import Condition="'$(RID)' == 'win-x86'" Project="targets\GenerateMSIs.targets" />
   <Target Condition="'$(RID)' == 'win-x86'" Name="GenerateMSIs" AfterTargets="Build" DependsOnTargets="GenerateLayout;GenerateDotnetCoreUninstallMsi" />
-  <Target Condition="'$(RID)' == 'win-x86'" Name="SignBeforMSIs" BeforeTargets="GenerateDotnetCoreUninstallMsi" DependsOnTargets="SignFiles" />
-
 </Project>

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -96,7 +96,7 @@
     <CreateLightCommandPackageDrop
       LightCommandWorkingDir="$(LightCommandObjDir)"
       OutputFolder="$(LightCommandPackagesDir)"
-      AdditionalBasePaths="$(DotnetCoreUninstallOutputDirectory)"
+      AdditionalBasePaths="$(MSBuildThisFileDirectory)/packaging/windows/dotnetCoreUninstall"
       Cultures="en-us" 
       InstallerFile="$(DotnetCoreUninstallMSIInstallerFile)"
       WixExtensions="WixUIExtension;WixDependencyExtension;WixUtilExtension"

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -88,7 +88,7 @@
       <!-- Temp directory for light command layouts -->
       <LightCommandObjDir>$(ArtifactsObjDir)/LightCommandPackages</LightCommandObjDir>
       <!-- Directory for the zipped up light command package -->
-      <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
+      <LightCommandPackagesDir>$(ArtifactsShippingPackagesDir)</LightCommandPackagesDir>
     </PropertyGroup>
     <ItemGroup>
         <UninstallerMsiWixSrcFiles Include="$(WixRoot)\*.wixobj" />

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -75,7 +75,13 @@
           Inputs="$(DotnetCoreUninstallOutputDirectory)**/*;
                     $(DotnetCoreUninstallGenerateMsiPowershellScript)"
           Outputs="$(DotnetCoreUninstallMSIInstallerFile)">
-
+    <PropertyGroup>
+      <SdkPkgSourcesRootDirectory>$(MSBuildThisFileDirectory)../packaging/windows</SdkPkgSourcesRootDirectory>
+      <!-- Temp directory for light command layouts -->
+      <LightCommandObjDir>$(ArtifactsObjDir)/LightCommandPackages</LightCommandObjDir>
+      <!-- Directory for the zipped up light command package -->
+      <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
+    </PropertyGroup>
     <Exec Command="powershell -NoProfile -NoLogo $(DotnetCoreUninstallGenerateMsiPowershellScript) ^
                       '$(DotnetCoreUninstallOutputDirectory.TrimEnd('\'))' ^
                       '$(DotnetCoreUninstallMSIInstallerFile)' ^
@@ -85,6 +91,14 @@
                       '$(DotnetCoreUninstallInstallerUpgradeCode)' ^
                       '$(Architecture)' ^
                       -InformationAction Continue" />
+    <CreateLightCommandPackageDrop
+      LightCommandWorkingDir="$(LightCommandObjDir)"
+      OutputFolder="$(LightCommandPackagesDir)"
+      NoLogo="true"
+      WixExtensions="WixUIExtension;WixDependencyExtension;WixUtilExtension"
+      Cultures="en-us" >
+      <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />
+    </CreateLightCommandPackageDrop>
   </Target>
 
 </Project>

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -32,10 +32,10 @@
   <Target Name="MsiTargetsSetupInputOutputs"
           DependsOnTargets="GenerateLayout;SetupWixProperties;GetDotnetCoreUninstallGitCommitInfo">
 
-    <GenerateMsiVersion CommitCount="$(GitCommitCount)"
-                        VersionMajor="$(VersionMajor)"
-                        VersionMinor="$(VersionMinor)"
-                        VersionPatch="$(VersionPatch)">
+    <GenerateMsiVersion BuildNumber="$(GitCommitCount)"
+                        Major="$(VersionMajor)"
+                        Minor="$(VersionMinor)"
+                        Patch="$(VersionPatch)">
       <Output TaskParameter="MsiVersion" PropertyName="MsiVersion" />
     </GenerateMsiVersion>
 
@@ -75,13 +75,6 @@
           Inputs="$(DotnetCoreUninstallOutputDirectory)**/*;
                     $(DotnetCoreUninstallGenerateMsiPowershellScript)"
           Outputs="$(DotnetCoreUninstallMSIInstallerFile)">
-    <PropertyGroup>
-      <SdkPkgSourcesRootDirectory>$(MSBuildThisFileDirectory)../packaging/windows</SdkPkgSourcesRootDirectory>
-      <!-- Temp directory for light command layouts -->
-      <LightCommandObjDir>$(ArtifactsObjDir)/LightCommandPackages</LightCommandObjDir>
-      <!-- Directory for the zipped up light command package -->
-      <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
-    </PropertyGroup>
     <Exec Command="powershell -NoProfile -NoLogo $(DotnetCoreUninstallGenerateMsiPowershellScript) ^
                       '$(DotnetCoreUninstallOutputDirectory.TrimEnd('\'))' ^
                       '$(DotnetCoreUninstallMSIInstallerFile)' ^
@@ -91,12 +84,24 @@
                       '$(DotnetCoreUninstallInstallerUpgradeCode)' ^
                       '$(Architecture)' ^
                       -InformationAction Continue" />
+    <PropertyGroup>
+      <!-- Temp directory for light command layouts -->
+      <LightCommandObjDir>$(ArtifactsObjDir)/LightCommandPackages</LightCommandObjDir>
+      <!-- Directory for the zipped up light command package -->
+      <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
+    </PropertyGroup>
+    <ItemGroup>
+        <SdkMsiWixSrcFiles Include="$(WixRoot)\*.wixobj" />
+    </ItemGroup>
     <CreateLightCommandPackageDrop
       LightCommandWorkingDir="$(LightCommandObjDir)"
       OutputFolder="$(LightCommandPackagesDir)"
+      AdditionalBasePaths="$(DotnetCoreUninstallOutputDirectory)"
       NoLogo="true"
+      Cultures="en-us" 
+      InstallerFile="$(DotnetCoreUninstallMSIInstallerFile)"
       WixExtensions="WixUIExtension;WixDependencyExtension;WixUtilExtension"
-      Cultures="en-us" >
+      WixSrcFiles="@(SdkMsiWixSrcFiles)">
       <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />
     </CreateLightCommandPackageDrop>
   </Target>

--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -91,17 +91,16 @@
       <LightCommandPackagesDir>$(ArtifactsNonShippingPackagesDir)</LightCommandPackagesDir>
     </PropertyGroup>
     <ItemGroup>
-        <SdkMsiWixSrcFiles Include="$(WixRoot)\*.wixobj" />
+        <UninstallerMsiWixSrcFiles Include="$(WixRoot)\*.wixobj" />
     </ItemGroup>
     <CreateLightCommandPackageDrop
       LightCommandWorkingDir="$(LightCommandObjDir)"
       OutputFolder="$(LightCommandPackagesDir)"
       AdditionalBasePaths="$(DotnetCoreUninstallOutputDirectory)"
-      NoLogo="true"
       Cultures="en-us" 
       InstallerFile="$(DotnetCoreUninstallMSIInstallerFile)"
       WixExtensions="WixUIExtension;WixDependencyExtension;WixUtilExtension"
-      WixSrcFiles="@(SdkMsiWixSrcFiles)">
+      WixSrcFiles="@(UninstallerMsiWixSrcFiles)">
       <Output TaskParameter="OutputFile" PropertyName="_LightCommandPackageNameOutput" />
     </CreateLightCommandPackageDrop>
   </Target>

--- a/src/redist/targets/packaging/windows/dotnetCoreUninstall/dotnet.wxs
+++ b/src/redist/targets/packaging/windows/dotnetCoreUninstall/dotnet.wxs
@@ -5,8 +5,8 @@
     <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200" />
 
     <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
-    <WixVariable Id="WixUIBannerBmp" Value="images/dotnetbanner.png" />
-    <WixVariable Id="WixUIDialogBmp" Value="images/dotnetbackground.png" />
+    <!-- <WixVariable Id="WixUIBannerBmp" Value="images/dotnetbanner.png" /> -->
+    <!-- <WixVariable Id="WixUIDialogBmp" Value="images/dotnetbackground.png" /> -->
 
     <?if $(var.Platform)=x86?>
     <MediaTemplate EmbedCab="yes" />

--- a/src/redist/targets/packaging/windows/dotnetCoreUninstall/dotnet.wxs
+++ b/src/redist/targets/packaging/windows/dotnetCoreUninstall/dotnet.wxs
@@ -5,8 +5,8 @@
     <Package Compressed="yes" InstallScope="perMachine" InstallerVersion="200" />
 
     <MajorUpgrade DowngradeErrorMessage="$(var.DowngradeErrorMessage)" Schedule="afterInstallInitialize"/>
-    <!-- <WixVariable Id="WixUIBannerBmp" Value="images/dotnetbanner.png" /> -->
-    <!-- <WixVariable Id="WixUIDialogBmp" Value="images/dotnetbackground.png" /> -->
+    <WixVariable Id="WixUIBannerBmp" Value="images/dotnetbanner.png" />
+    <WixVariable Id="WixUIDialogBmp" Value="images/dotnetbackground.png" />
 
     <?if $(var.Platform)=x86?>
     <MediaTemplate EmbedCab="yes" />


### PR DESCRIPTION
MSI contents were not correctly signed on Windows. Using [`CreateLightCommandPackageDrop`](https://github.com/dotnet/arcade/tree/main/src/Microsoft.DotNet.Build.Tasks.Installers#task-usage) to handle re-packaging and signing of resulting .msi file. 
