### PR TITLE
Update CLI options and help text

### DIFF
--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -623,24 +623,6 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The type of bundle you want to uninstall. ({0}).
-        /// </summary>
-        internal static string UninstallTargetArgumentDescription {
-            get {
-                return ResourceManager.GetString("UninstallTargetArgumentDescription", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to TARGET.
-        /// </summary>
-        internal static string UninstallTargetArgumentName {
-            get {
-                return ResourceManager.GetString("UninstallTargetArgumentName", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Can be used with --sdk, --runtime and --aspnet-runtime to remove x64..
         /// </summary>
         internal static string UninstallX64OptionDescription {

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -623,6 +623,24 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The type of bundle you want to uninstall. (--sdk, --runtime).
+        /// </summary>
+        internal static string UninstallTargetArgumentDescription {
+            get {
+                return ResourceManager.GetString("UninstallTargetArgumentDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to TARGET.
+        /// </summary>
+        internal static string UninstallTargetArgumentName {
+            get {
+                return ResourceManager.GetString("UninstallTargetArgumentName", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Can be used with --sdk, --runtime and --aspnet-runtime to remove x64..
         /// </summary>
         internal static string UninstallX64OptionDescription {

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -470,7 +470,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove all .NET Core SDKs or Runtimes. (*).
+        ///   Looks up a localized string similar to Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*).
         /// </summary>
         internal static string UninstallAllOptionDescription {
             get {

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -623,7 +623,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The type of bundle you want to uninstall. (--sdk, --runtime).
+        ///   Looks up a localized string similar to The type of bundle you want to uninstall. ({0}).
         /// </summary>
         internal static string UninstallTargetArgumentDescription {
             get {

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -470,7 +470,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*).
+        ///   Looks up a localized string similar to Remove all .NET Core SDKs or Runtimes. (*).
         /// </summary>
         internal static string UninstallAllOptionDescription {
             get {

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -151,6 +151,15 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to List arm64 .NET Core SDKs or Runtimes..
+        /// </summary>
+        internal static string ListArm64OptionDescription {
+            get {
+                return ResourceManager.GetString("ListArm64OptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to List ASP.NET Core Runtimes..
         /// </summary>
         internal static string ListAspNetRuntimeOptionDescription {
@@ -493,6 +502,15 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string UninstallAllPreviewsOptionDescription {
             get {
                 return ResourceManager.GetString("UninstallAllPreviewsOptionDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64..
+        /// </summary>
+        internal static string UninstallArm64OptionDescription {
+            get {
+                return ResourceManager.GetString("UninstallArm64OptionDescription", resourceCulture);
             }
         }
         

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download..
+        ///   Looks up a localized string similar to (*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download..
         /// </summary>
         internal static string HelpExplanationParagraphMac {
             get {
@@ -124,7 +124,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download..
+        ///   Looks up a localized string similar to (*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download..
         /// </summary>
         internal static string HelpExplanationParagraphWindows {
             get {

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -169,7 +169,7 @@
     <value>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</value>
   </data>
   <data name="UninstallAllOptionDescription" xml:space="preserve">
-    <value>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</value>
+    <value>Remove all .NET Core SDKs or Runtimes. (*)</value>
   </data>
   <data name="UninstallAllPreviewsButLatestOptionDescription" xml:space="preserve">
     <value>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</value>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -390,10 +390,4 @@ Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio for to break.
 </value>
   </data>
-  <data name="UninstallTargetArgumentName" xml:space="preserve">
-    <value>TARGET</value>
-  </data>
-  <data name="UninstallTargetArgumentDescription" xml:space="preserve">
-    <value>The type of bundle you want to uninstall. ({0})</value>
-  </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -390,4 +390,10 @@ Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio for to break.
 </value>
   </data>
+  <data name="ListArm64OptionDescription" xml:space="preserve">
+    <value>List arm64 .NET Core SDKs or Runtimes.</value>
+  </data>
+  <data name="UninstallArm64OptionDescription" xml:space="preserve">
+    <value>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</value>
+  </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -394,6 +394,6 @@ Uninstalling this item will cause Visual Studio for to break.
     <value>TARGET</value>
   </data>
   <data name="UninstallTargetArgumentDescription" xml:space="preserve">
-    <value>The type of bundle you want to uninstall. (--sdk, --runtime)</value>
+    <value>The type of bundle you want to uninstall. ({0})</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -169,7 +169,7 @@
     <value>Remove .NET Core SDKs or Runtimes superseded by higher patches. Protects global.json. (*)</value>
   </data>
   <data name="UninstallAllOptionDescription" xml:space="preserve">
-    <value>Remove all .NET Core SDKs or Runtimes. (*)</value>
+    <value>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</value>
   </data>
   <data name="UninstallAllPreviewsButLatestOptionDescription" xml:space="preserve">
     <value>Remove .NET Core SDKs or Runtimes marked as previews, except the one highest preview. (*)</value>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -390,4 +390,10 @@ Warning: {0}: {1}
 Uninstalling this item will cause Visual Studio for to break.
 </value>
   </data>
+  <data name="UninstallTargetArgumentName" xml:space="preserve">
+    <value>TARGET</value>
+  </data>
+  <data name="UninstallTargetArgumentDescription" xml:space="preserve">
+    <value>The type of bundle you want to uninstall. (--sdk, --runtime)</value>
+  </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -353,10 +353,10 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </value>
   </data>
   <data name="HelpExplanationParagraphMac" xml:space="preserve">
-    <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</value>
+    <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
   </data>
   <data name="HelpExplanationParagraphWindows" xml:space="preserve">
-    <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</value>
+    <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
   </data>
   <data name="MacConfirmationPromptOutputFormat" xml:space="preserve">
     <value>The following items will be removed:

--- a/src/dotnet-core-uninstall/Shared/BundleInfo/BundleArch.cs
+++ b/src/dotnet-core-uninstall/Shared/BundleInfo/BundleArch.cs
@@ -10,6 +10,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo
     {
         X86 = 0x1,
         X64 = 0x2,
-        Arm64 = 0x3
+        Arm64 = 0x4
     }
 }

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -363,6 +363,12 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
                     Description = LocalizableStrings.UninstallNoOptionArgumentDescription
                 });
             }
+            // TODO: Check
+            command.AddArgument(new Argument<IEnumerable<string>>
+            {
+                Name = "TARGET",
+                Description = "The type you want to uninstall"
+            });
         }
     }
 }

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -355,6 +355,14 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             {
                 command.AddOption(option);
             }
+            
+            // Arguments
+            command.AddArgument(new Argument<IEnumerable<string>>
+            {
+                Name = "TARGET",
+                Description = "The type of bundle you want to uninstall. (--sdk, --runtime)"
+            });
+
             if (addVersionArgument)
             {
                 command.AddArgument(new Argument<IEnumerable<string>>
@@ -363,12 +371,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
                     Description = LocalizableStrings.UninstallNoOptionArgumentDescription
                 });
             }
-            // TODO: Check
-            command.AddArgument(new Argument<IEnumerable<string>>
-            {
-                Name = "TARGET",
-                Description = "The type you want to uninstall"
-            });
         }
     }
 }

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -355,14 +355,16 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             {
                 command.AddOption(option);
             }
-            
-            // Arguments
-            command.AddArgument(new Argument<IEnumerable<string>>
+            if (command.Name != ListCommandName)
             {
-                Name = "TARGET",
-                Description = "The type of bundle you want to uninstall. (--sdk, --runtime)"
-            });
-
+                // Arguments
+                command.AddArgument(new Argument<IEnumerable<string>>
+                {
+                    Name = "TARGET",
+                    Description = "The type of bundle you want to uninstall. (--sdk, --runtime)"
+                });
+            }
+            
             if (addVersionArgument)
             {
                 command.AddArgument(new Argument<IEnumerable<string>>

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -150,18 +150,18 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
         public static readonly Option[] ListBundleTypeOptions = new Option[]
         {
-            new Option($"--{SdkOptionName}", LocalizableStrings.ListSdkOptionDescription) { IsHidden = true },
-            new Option($"--{RuntimeOptionName}", LocalizableStrings.ListRuntimeOptionDescription) { IsHidden = true },
-            new Option($"--{AspNetRuntimeOptionName}", LocalizableStrings.ListAspNetRuntimeOptionDescription) { IsHidden = true },
-            new Option($"--{HostingBundleOptionName}", LocalizableStrings.ListHostingBundleOptionDescription) { IsHidden = true }
+            new Option($"--{SdkOptionName}", LocalizableStrings.ListSdkOptionDescription),
+            new Option($"--{RuntimeOptionName}", LocalizableStrings.ListRuntimeOptionDescription),
+            new Option($"--{AspNetRuntimeOptionName}", LocalizableStrings.ListAspNetRuntimeOptionDescription),
+            new Option($"--{HostingBundleOptionName}", LocalizableStrings.ListHostingBundleOptionDescription)
         };
 
         public static readonly Option[] UninstallBundleTypeOptions = new Option[]
         {
-            new Option($"--{SdkOptionName}", LocalizableStrings.UninstallSdkOptionDescription) { IsHidden = true },
-            new Option($"--{RuntimeOptionName}", LocalizableStrings.UninstallRuntimeOptionDescription) { IsHidden = true },
-            new Option($"--{AspNetRuntimeOptionName}", LocalizableStrings.UninstallAspNetRuntimeOptionDescription) { IsHidden = true },
-            new Option($"--{HostingBundleOptionName}", LocalizableStrings.UninstallHostingBundleOptionDescription) { IsHidden = true }
+            new Option($"--{SdkOptionName}", LocalizableStrings.UninstallSdkOptionDescription),
+            new Option($"--{RuntimeOptionName}", LocalizableStrings.UninstallRuntimeOptionDescription),
+            new Option($"--{AspNetRuntimeOptionName}", LocalizableStrings.UninstallAspNetRuntimeOptionDescription),
+            new Option($"--{HostingBundleOptionName}", LocalizableStrings.UninstallHostingBundleOptionDescription)
         };
 
         public static readonly Option[] ArchUninstallOptions = new Option[]
@@ -355,19 +355,6 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             {
                 command.AddOption(option);
             }
-            if (command.Name != ListCommandName)
-            {
-                // Arguments
-                command.AddArgument(new Argument<IEnumerable<string>>
-                {
-                    Name = LocalizableStrings.UninstallTargetArgumentName,
-                    Description = string.Format(
-                        LocalizableStrings.UninstallTargetArgumentDescription,
-                        string.Join(", ", SupportedBundleTypeConfigs.GetSupportedBundleTypes().Select(type => $"--{type.OptionName}"))
-                    )
-                });
-            }
-            
             if (addVersionArgument)
             {
                 command.AddArgument(new Argument<IEnumerable<string>>

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -361,7 +361,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
                 command.AddArgument(new Argument<IEnumerable<string>>
                 {
                     Name = LocalizableStrings.UninstallTargetArgumentName,
-                    Description = LocalizableStrings.UninstallTargetArgumentDescription,
+                    Description = string.Format(
+                        LocalizableStrings.UninstallTargetArgumentDescription,
+                        string.Join(", ", SupportedBundleTypeConfigs.GetSupportedBundleTypes().Select(type => $"--{type.OptionName}"))
+                    )
                 });
             }
             

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -122,6 +122,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             $"--{X86OptionName}",
             LocalizableStrings.ListX86OptionDescription);
 
+        public static readonly Option ListArm64Option = new Option(
+            $"--{Arm64OptionName}",
+            LocalizableStrings.ListArm64OptionDescription);
+
         public static readonly Command VersionSubcommand = new Command("--version")
         {
             IsHidden = true
@@ -167,7 +171,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
         public static readonly Option[] ArchUninstallOptions = new Option[]
         {
             new Option($"--{X64OptionName}", LocalizableStrings.UninstallX64OptionDescription),
-            new Option($"--{X86OptionName}", LocalizableStrings.UninstallX86OptionDescription)
+            new Option($"--{X86OptionName}", LocalizableStrings.UninstallX86OptionDescription),
+            new Option($"--{Arm64OptionName}", LocalizableStrings.UninstallArm64OptionDescription)
         };
 
         public static readonly Option[] AdditionalUninstallOptions = new Option[]
@@ -244,7 +249,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             {
                 ListAuxOptions = ListAuxOptions
                     .Append(ListX64Option)
-                    .Append(ListX86Option);
+                    .Append(ListX86Option)
+                    .Append(ListArm64Option);
             }
             AssignOptionsToCommand(ListCommand, ListAuxOptions);
 

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -150,18 +150,18 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
 
         public static readonly Option[] ListBundleTypeOptions = new Option[]
         {
-            new Option($"--{SdkOptionName}", LocalizableStrings.ListSdkOptionDescription),
-            new Option($"--{RuntimeOptionName}", LocalizableStrings.ListRuntimeOptionDescription),
-            new Option($"--{AspNetRuntimeOptionName}", LocalizableStrings.ListAspNetRuntimeOptionDescription),
-            new Option($"--{HostingBundleOptionName}", LocalizableStrings.ListHostingBundleOptionDescription)
+            new Option($"--{SdkOptionName}", LocalizableStrings.ListSdkOptionDescription) { IsHidden = true },
+            new Option($"--{RuntimeOptionName}", LocalizableStrings.ListRuntimeOptionDescription) { IsHidden = true },
+            new Option($"--{AspNetRuntimeOptionName}", LocalizableStrings.ListAspNetRuntimeOptionDescription) { IsHidden = true },
+            new Option($"--{HostingBundleOptionName}", LocalizableStrings.ListHostingBundleOptionDescription) { IsHidden = true }
         };
 
         public static readonly Option[] UninstallBundleTypeOptions = new Option[]
         {
-            new Option($"--{SdkOptionName}", LocalizableStrings.UninstallSdkOptionDescription),
-            new Option($"--{RuntimeOptionName}", LocalizableStrings.UninstallRuntimeOptionDescription),
-            new Option($"--{AspNetRuntimeOptionName}", LocalizableStrings.UninstallAspNetRuntimeOptionDescription),
-            new Option($"--{HostingBundleOptionName}", LocalizableStrings.UninstallHostingBundleOptionDescription)
+            new Option($"--{SdkOptionName}", LocalizableStrings.UninstallSdkOptionDescription) { IsHidden = true },
+            new Option($"--{RuntimeOptionName}", LocalizableStrings.UninstallRuntimeOptionDescription) { IsHidden = true },
+            new Option($"--{AspNetRuntimeOptionName}", LocalizableStrings.UninstallAspNetRuntimeOptionDescription) { IsHidden = true },
+            new Option($"--{HostingBundleOptionName}", LocalizableStrings.UninstallHostingBundleOptionDescription) { IsHidden = true }
         };
 
         public static readonly Option[] ArchUninstallOptions = new Option[]

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -360,8 +360,8 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
                 // Arguments
                 command.AddArgument(new Argument<IEnumerable<string>>
                 {
-                    Name = "TARGET",
-                    Description = "The type of bundle you want to uninstall. (--sdk, --runtime)"
+                    Name = LocalizableStrings.UninstallTargetArgumentName,
+                    Description = LocalizableStrings.UninstallTargetArgumentDescription,
                 });
             }
             

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -336,6 +336,16 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
+      <trans-unit id="UninstallTargetArgumentDescription">
+        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
+        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallTargetArgumentName">
+        <source>TARGET</source>
+        <target state="new">TARGET</target>
+        <note />
+      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -337,8 +337,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. (--sdk, --runtime)</source>
-        <target state="new">The type of bundle you want to uninstall. (--sdk, --runtime)</target>
+        <source>The type of bundle you want to uninstall. ({0})</source>
+        <target state="new">The type of bundle you want to uninstall. ({0})</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallTargetArgumentName">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,13 +33,13 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at aka.ms/dotnet-core-download.</target>
+        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HostingBundleFootnoteFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -52,6 +52,11 @@
         <target state="new">The specified version is not valid: "{0}".</target>
         <note />
       </trans-unit>
+      <trans-unit id="ListArm64OptionDescription">
+        <source>List arm64 .NET Core SDKs or Runtimes.</source>
+        <target state="new">List arm64 .NET Core SDKs or Runtimes.</target>
+        <note />
+      </trans-unit>
       <trans-unit id="ListAspNetRuntimeOptionDescription">
         <source>List ASP.NET Core Runtimes.</source>
         <target state="new">List ASP.NET Core Runtimes.</target>
@@ -274,6 +279,11 @@ Uninstalling this item will cause Visual Studio for to break.
       <trans-unit id="UninstallAllPreviewsOptionDescription">
         <source>Remove .NET Core SDKs or Runtimes marked as previews. (*)</source>
         <target state="new">Remove .NET Core SDKs or Runtimes marked as previews. (*)</target>
+        <note />
+      </trans-unit>
+      <trans-unit id="UninstallArm64OptionDescription">
+        <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</source>
+        <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAspNetRuntimeOptionDescription">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -336,16 +336,6 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Remove .NET Core SDKs only.</target>
         <note />
       </trans-unit>
-      <trans-unit id="UninstallTargetArgumentDescription">
-        <source>The type of bundle you want to uninstall. ({0})</source>
-        <target state="new">The type of bundle you want to uninstall. ({0})</target>
-        <note />
-      </trans-unit>
-      <trans-unit id="UninstallTargetArgumentName">
-        <source>TARGET</source>
-        <target state="new">TARGET</target>
-        <note />
-      </trans-unit>
       <trans-unit id="UninstallX64OptionDescription">
         <source>Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</source>
         <target state="new">Can be used with --sdk, --runtime and --aspnet-runtime to remove x64.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -262,8 +262,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllOptionDescription">
-        <source>Remove all .NET Core SDKs or Runtimes. (*)</source>
-        <target state="new">Remove all .NET Core SDKs or Runtimes. (*)</target>
+        <source>Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</source>
+        <target state="new">Remove all .NET Core SDKs or Runtimes. (Must specify one of: --aspnet-runtime, --hosting-bundle, --runtime, --sdk). (*)</target>
         <note />
       </trans-unit>
       <trans-unit id="UninstallAllPreviewsButLatestOptionDescription">


### PR DESCRIPTION
Addresses #312 to make help text clearer. 
> [!NOTE]
> [Docs](https://learn.microsoft.com/en-us/dotnet/core/additional-tools/uninstall-tool-cli-remove) will also be updated to match help text here. 

Adds support for `--arm64` option on Windows.
