### PR TITLE
Update to AwesomeAssertions

### DIFF
--- a/test/MSBuildBinLogQuery.Tests/MSBuildBinLogQuery.Tests.csproj
+++ b/test/MSBuildBinLogQuery.Tests/MSBuildBinLogQuery.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="AwesomeAssertions" Version="8.0.2" />
   </ItemGroup>
 
 </Project>

--- a/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/Commands/CommandBundleFilterTests.cs
@@ -105,14 +105,14 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.Commands
 
         internal void TestRequiredUninstallableWhenExplicitlyAdded(IEnumerable<Bundle> bundles, string command, string[] expectedUninstallableSdk, string[] expectedUninstallableRuntime)
         {
-            using var scope = new AssertionScope();
-            scope.AddReportable("bundles", () => String.Join(Environment.NewLine, bundles.Select(b => b.ToDebugString())));
-            scope.AddReportable("command", () => command);
-            scope.AddReportable("expectedUninstallableSdk", () => String.Join(Environment.NewLine, expectedUninstallableSdk));
-            scope.AddReportable("expectedUninstallableRuntime", () => String.Join(Environment.NewLine, expectedUninstallableRuntime));
+            var chain = AssertionChain.GetOrCreate();
+            chain.AddReportable("bundles", () => String.Join(Environment.NewLine, bundles.Select(b => b.ToDebugString())));
+            chain.AddReportable("command", () => command);
+            chain.AddReportable("expectedUninstallableSdk", () => String.Join(Environment.NewLine, expectedUninstallableSdk));
+            chain.AddReportable("expectedUninstallableRuntime", () => String.Join(Environment.NewLine, expectedUninstallableRuntime));
             var parseResult = CommandLineConfigs.UninstallRootCommand.Parse(command);
             var uninstallableBundles = CommandBundleFilter.GetFilteredBundles(bundles, parseResult);
-            scope.AddReportable("uninstallableBundles", () => String.Join(Environment.NewLine, uninstallableBundles.Select(b => b.ToDebugString())));
+            chain.AddReportable("uninstallableBundles", () => String.Join(Environment.NewLine, uninstallableBundles.Select(b => b.ToDebugString())));
 
             var uninstallableSdks = uninstallableBundles.Where(b => b.Version is SdkVersion).Select(b => b.DisplayName);
             var requiredSdks = bundles.Except(uninstallableBundles).Where(b => b.Version is SdkVersion).Select(b => b.DisplayName);

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection.Metadata;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;

--- a/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
+++ b/test/dotnet-core-uninstall.Tests/Shared/VSVersioning/VSVersionTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Metadata;
 using FluentAssertions;
 using FluentAssertions.Execution;
 using Microsoft.DotNet.Tools.Uninstall.Shared.BundleInfo;
@@ -136,9 +137,9 @@ namespace Microsoft.DotNet.Tools.Uninstall.Tests.Shared.VSVersioning
 
         private void CheckAllowed(IEnumerable<Bundle> allBundles, IEnumerable<Bundle> uninstallableBundles, bool[] sdkAllowed, bool[] runtimeAllowed)
         {
-            using var scope = new AssertionScope();
-            scope.AddReportable("allBundles", () => String.Join(Environment.NewLine, allBundles.Select(b => b.ToDebugString())));
-            scope.AddReportable("uninstallableBundles", () => String.Join(Environment.NewLine, uninstallableBundles.Select(b => b.ToDebugString())));
+            var chain = AssertionChain.GetOrCreate();
+            chain.AddReportable("allBundles", () => String.Join(Environment.NewLine, allBundles.Select(b => b.ToDebugString())));
+            chain.AddReportable("uninstallableBundles", () => String.Join(Environment.NewLine, uninstallableBundles.Select(b => b.ToDebugString())));
             var sdkBundles = allBundles.Where(bundle => bundle.Version is SdkVersion).ToArray();
             var runtimeBundles = allBundles.Where(bundle => bundle.Version is RuntimeVersion).ToArray();
             var otherBundles = allBundles.Except(sdkBundles).Except(runtimeBundles);

--- a/test/dotnet-core-uninstall.Tests/dotnet-core-uninstall.Tests.csproj
+++ b/test/dotnet-core-uninstall.Tests/dotnet-core-uninstall.Tests.csproj
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.7.0" />
+    <PackageReference Include="AwesomeAssertions" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
With FluentAssertions version 8 changing their license, we're exploring alternative solutions. While we use the 6 version today, if there were a security reason to update in the future, we want to ensure we're on a supported version.

Update the addreportable call