### PR TITLE
Update help text

### DIFF
--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download..
+        ///   Looks up a localized string similar to (*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download..
         /// </summary>
         internal static string HelpExplanationParagraphMac {
             get {
@@ -309,7 +309,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported)..
+        ///   Looks up a localized string similar to Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support)..
         /// </summary>
         internal static string MacOSPreserveVSSdksOptionDescription {
             get {
@@ -321,7 +321,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         ///   Looks up a localized string similar to 
         ///{0}: {1}
         ///
-        ///Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+        ///Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
         ///
         ///Are you sure you want to continue? [y/n] .
         /// </summary>
@@ -353,7 +353,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported)..
+        ///   Looks up a localized string similar to Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support)..
         /// </summary>
         internal static string MacSDKRequirementExplanationString {
             get {

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download..
+        ///   Looks up a localized string similar to (*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download..
         /// </summary>
         internal static string HelpExplanationParagraphMac {
             get {
@@ -262,7 +262,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         ///   Looks up a localized string similar to The following items will be removed:
         ///{0}
         ///
-        ///To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+        ///for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
         ///
         ///Do you want to continue? [y/n] .
         /// </summary>
@@ -278,7 +278,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         ///{0}
         ///*** END DRY RUN OUTPUT
         ///
-        ///To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+        ///For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
         ///
         ///Run as administrator and use the remove command to uninstall these items..
         /// </summary>
@@ -309,7 +309,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Keep SDKs required for Visual Studio for Mac (Visual Studio for Mac is no longer supported).
+        ///   Looks up a localized string similar to Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported)..
         /// </summary>
         internal static string MacOSPreserveVSSdksOptionDescription {
             get {
@@ -321,7 +321,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         ///   Looks up a localized string similar to 
         ///{0}: {1}
         ///
-        ///Uninstalling this item will cause Visual Studio for Mac to break.
+        ///Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
         ///
         ///Are you sure you want to continue? [y/n] .
         /// </summary>
@@ -349,15 +349,6 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         internal static string MacRuntimeRequirementExplanationString {
             get {
                 return ResourceManager.GetString("MacRuntimeRequirementExplanationString", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Used by Visual Studio for Mac (Visual Studio for Mac is no longer supported). Specify individually or use —-force to remove.
-        /// </summary>
-        internal static string MacSDKRequirementExplanationString {
-            get {
-                return ResourceManager.GetString("MacSDKRequirementExplanationString", resourceCulture);
             }
         }
         

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download..
+        ///   Looks up a localized string similar to (*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download..
         /// </summary>
         internal static string HelpExplanationParagraphMac {
             get {

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -353,6 +353,15 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported)..
+        /// </summary>
+        internal static string MacSDKRequirementExplanationString {
+            get {
+                return ResourceManager.GetString("MacSDKRequirementExplanationString", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to You must specify exactly one version for option: {0}..
         /// </summary>
         internal static string MoreThanOneVersionSpecifiedExceptionMessageFormat {

--- a/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
+++ b/src/dotnet-core-uninstall/LocalizableStrings.Designer.cs
@@ -115,7 +115,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to (*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download..
+        ///   Looks up a localized string similar to (*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download..
         /// </summary>
         internal static string HelpExplanationParagraphMac {
             get {
@@ -262,7 +262,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         ///   Looks up a localized string similar to The following items will be removed:
         ///{0}
         ///
-        ///for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+        ///For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
         ///
         ///Do you want to continue? [y/n] .
         /// </summary>
@@ -309,7 +309,7 @@ namespace Microsoft.DotNet.Tools.Uninstall {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported)..
+        ///   Looks up a localized string similar to Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported)..
         /// </summary>
         internal static string MacOSPreserveVSSdksOptionDescription {
             get {

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -350,7 +350,7 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </value>
   </data>
   <data name="HelpExplanationParagraphMac" xml:space="preserve">
-    <value>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
+    <value>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
   </data>
   <data name="HelpExplanationParagraphWindows" xml:space="preserve">
     <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -396,4 +396,7 @@ Uninstalling this item will cause Visual Studio for to break.
   <data name="MacOSPreserveVSSdksOptionDescription" xml:space="preserve">
     <value>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</value>
   </data>
+  <data name="MacSDKRequirementExplanationString" xml:space="preserve">
+    <value>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</value>
+  </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -350,7 +350,7 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </value>
   </data>
   <data name="HelpExplanationParagraphMac" xml:space="preserve">
-    <value>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
+    <value>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
   </data>
   <data name="HelpExplanationParagraphWindows" xml:space="preserve">
     <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
@@ -359,7 +359,7 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
     <value>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </value>
   </data>
@@ -394,7 +394,7 @@ Uninstalling this item will cause Visual Studio for to break.
     <value>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</value>
   </data>
   <data name="MacOSPreserveVSSdksOptionDescription" xml:space="preserve">
-    <value>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</value>
+    <value>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</value>
   </data>
   <data name="MacSDKRequirementExplanationString" xml:space="preserve">
     <value>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</value>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -350,7 +350,7 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </value>
   </data>
   <data name="HelpExplanationParagraphMac" xml:space="preserve">
-    <value>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
+    <value>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
   </data>
   <data name="HelpExplanationParagraphWindows" xml:space="preserve">
     <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -350,7 +350,7 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </value>
   </data>
   <data name="HelpExplanationParagraphMac" xml:space="preserve">
-    <value>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
+    <value>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
   </data>
   <data name="HelpExplanationParagraphWindows" xml:space="preserve">
     <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
@@ -377,7 +377,7 @@ Run as administrator and use the remove command to uninstall these items.</value
     <value>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </value>
   </data>
@@ -394,9 +394,9 @@ Uninstalling this item will cause Visual Studio for to break.
     <value>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</value>
   </data>
   <data name="MacOSPreserveVSSdksOptionDescription" xml:space="preserve">
-    <value>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</value>
+    <value>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</value>
   </data>
   <data name="MacSDKRequirementExplanationString" xml:space="preserve">
-    <value>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</value>
+    <value>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/LocalizableStrings.resx
+++ b/src/dotnet-core-uninstall/LocalizableStrings.resx
@@ -350,7 +350,7 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </value>
   </data>
   <data name="HelpExplanationParagraphMac" xml:space="preserve">
-    <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
+    <value>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
   </data>
   <data name="HelpExplanationParagraphWindows" xml:space="preserve">
     <value>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</value>
@@ -359,7 +359,7 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
     <value>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </value>
   </data>
@@ -369,7 +369,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</value>
   </data>
@@ -377,7 +377,7 @@ Run as administrator and use the remove command to uninstall these items.</value
     <value>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </value>
   </data>
@@ -392,5 +392,8 @@ Uninstalling this item will cause Visual Studio for to break.
   </data>
   <data name="UninstallArm64OptionDescription" xml:space="preserve">
     <value>Can be used with --sdk, --runtime and --aspnet-runtime to remove arm64.</value>
+  </data>
+  <data name="MacOSPreserveVSSdksOptionDescription" xml:space="preserve">
+    <value>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</value>
   </data>
 </root>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.cs.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.de.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.es.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.fr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.it.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ja.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ko.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pl.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.pt-BR.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.ru.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.tr.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hans.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -196,6 +196,11 @@ Uninstalling this item will cause Visual Studio for to break.
         <target state="new">Used by SDKs. Specify individually or use —-force to remove</target>
         <note />
       </trans-unit>
+      <trans-unit id="MacSDKRequirementExplanationString">
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">
         <source>You must specify exactly one version for option: {0}.</source>
         <target state="new">You must specify exactly one version for option: {0}.</target>

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default, SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac or SDKs are not removed. To remove these, specify them individually or use --force. If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair”. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -116,13 +116,13 @@
         <source>The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </source>
         <target state="new">The following items will be removed:
 {0}
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+for any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Do you want to continue? [y/n] </target>
         <note />
@@ -133,7 +133,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</source>
         <target state="new">*** DRY RUN OUTPUT
@@ -141,7 +141,7 @@ Specified versions:
 {0}
 *** END DRY RUN OUTPUT
 
-To avoid breaking Visual Studio for Mac or other problems, read https://aka.ms/dotnet-core-uninstall-docs.
+For any problems, read https://aka.ms/dotnet-core-uninstall-docs.
 
 Run as administrator and use the remove command to uninstall these items.</target>
         <note />
@@ -155,6 +155,11 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
 </target>
         <note />
       </trans-unit>
+      <trans-unit id="MacOSPreserveVSSdksOptionDescription">
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studuio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <note />
+      </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
         <source>Microsoft .NET Core {0} {1} ({2})</source>
         <target state="new">Microsoft .NET Core {0} {1} ({2})</target>
@@ -164,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break.
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
 
 Are you sure you want to continue? [y/n] </target>
         <note />

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported). If removing SDKs or Runtimes causes issues with your installation of Visual Studio for Mac, run “Repair.” SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">
@@ -156,8 +156,8 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <note />
       </trans-unit>
       <trans-unit id="MacOSPreserveVSSdksOptionDescription">
-        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Prevent removal of SDKs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MacOsBundleDisplayNameFormat">
@@ -169,13 +169,13 @@ This tool cannot uninstall versions of the runtime or SDK that are installed usi
         <source>
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </source>
         <target state="new">
 {0}: {1}
 
-Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).
+Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).
 
 Are you sure you want to continue? [y/n] </target>
         <note />
@@ -197,8 +197,8 @@ Uninstalling this item will cause Visual Studio for to break.
         <note />
       </trans-unit>
       <trans-unit id="MacSDKRequirementExplanationString">
-        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</source>
-        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is now unsupported).</target>
+        <source>Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</source>
+        <target state="new">Uninstalling this item will cause Visual Studio for Mac to break. (Note: Visual Studio for Mac is out of support).</target>
         <note />
       </trans-unit>
       <trans-unit id="MoreThanOneVersionSpecifiedExceptionMessageFormat">

--- a/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
+++ b/src/dotnet-core-uninstall/xlf/LocalizableStrings.zh-Hant.xlf
@@ -33,8 +33,8 @@
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphMac">
-        <source>(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
-        <target state="new">(*) By default Runtimes that have a high probability of being used by SDKs are not removed. To remove these, specify them individually or use --force. To avoid issues with Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) use ----preserve-vs-for-mac-sdks, SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
+        <source>(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</source>
+        <target state="new">(*) Use --preserve-vs-for-mac-sdks to prevent removal of SDs and Runtimes that have a high probability of being used by Visual Studio for Mac (Note: Visual Studio for Mac is now unsupported) or SDKs. SDKs and Runtimes are available for download at https://aka.ms/dotnet-core-download.</target>
         <note />
       </trans-unit>
       <trans-unit id="HelpExplanationParagraphWindows">


### PR DESCRIPTION
Updates help text to better reflect new `--preserve-vs-for-mac-sdks` flag, and to remove references for VSfM