### PR TITLE
Update options

### DIFF
--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -126,8 +126,10 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             $"--{Arm64OptionName}",
             LocalizableStrings.ListArm64OptionDescription);
 
-        public static readonly Command VersionSubcommand = new Command("--version");
-
+        public static readonly Command VersionSubcommand = new Command("--version")
+        {
+            Description = LocalizableStrings.VersionOptionDescription
+        };
         public static readonly Option YesOption = new Option(
             new[] { "--yes", "-y" },
             LocalizableStrings.YesOptionDescription);

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -227,6 +227,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             {
                 ListCommand.AddOption(MacOSPreserveVSSdksOption);
                 RemoveCommand.AddOption(MacOSPreserveVSSdksOption);
+                DryRunCommand.AddOption(MacOSPreserveVSSdksOption);
             }
 
             var supportedBundleTypeNames = SupportedBundleTypeConfigs.GetSupportedBundleTypes().Select(type => type.OptionName);

--- a/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
+++ b/src/dotnet-core-uninstall/Shared/Configs/CommandLineConfigs.cs
@@ -126,10 +126,7 @@ namespace Microsoft.DotNet.Tools.Uninstall.Shared.Configs
             $"--{Arm64OptionName}",
             LocalizableStrings.ListArm64OptionDescription);
 
-        public static readonly Command VersionSubcommand = new Command("--version")
-        {
-            IsHidden = true
-        };
+        public static readonly Command VersionSubcommand = new Command("--version");
 
         public static readonly Option YesOption = new Option(
             new[] { "--yes", "-y" },


### PR DESCRIPTION
Fixes #379 to add `--preserve-vs-for-mac-sdks` option to `dry-run`.
Fixes #378 to not hide `--version` in the help text.

![image](https://github.com/user-attachments/assets/058ac48d-b6ee-4dc1-aa01-4b52e5873205)
