### PR TITLE
CI check signatures

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -33,7 +33,6 @@ extends:
       binskim:
         analyzeTargetGlob: $(Build.SourcesDirectory)/artifacts/bin/**.dll;$(Build.SourcesDirectory)/artifacts/bin/**.exe;
     pool:
-      pool:
       name: $(DncEngInternalBuildPool)
       image: 1es-windows-2022
       os: windows

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -110,14 +110,15 @@ extends:
               inputs:
                 sourceFolder: 'artifacts/packages/$(_BuildConfig)/Shipping/'
                 contents: '*.msi'
-                targetFolder: '$(Build.ArtifactStagingDirectory)'
+                targetFolder: '$(Build.ArtifactStagingDirectory)\artifacts'
             - task: MicroBuildCodesignVerify@3
               inputs:
-                TargetFolders: '$(Build.ArtifactStagingDirectory)'
+                TargetFolders: '$(Build.ArtifactStagingDirectory)\artifacts'
+                ExcludeFolders: '.git MicroBuild'
             - task: 1ES.PublishBuildArtifacts@1
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:
-                PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+                PathtoPublish: '$(Build.ArtifactStagingDirectory)\artifacts'
                 ArtifactName: 'drop-windows'
                 publishLocation: 'Container'
                 parallel: true
@@ -154,12 +155,12 @@ extends:
                 includeRootFolder: false
                 archiveType: 'tar'
                 tarCompression: 'gz'
-                archiveFile: '$(Build.ArtifactStagingDirectory)/dotnet-core-uninstall.tar.gz'
+                archiveFile: '$(Build.ArtifactStagingDirectory)/artifacts/dotnet-core-uninstall.tar.gz'
                 replaceExistingArchive: true
             - task: 1ES.PublishBuildArtifacts@1
               condition: eq(variables['system.pullrequest.isfork'], false)
               inputs:
-                PathtoPublish: '$(Build.ArtifactStagingDirectory)'
+                PathtoPublish: '$(Build.ArtifactStagingDirectory)/artifacts'
                 ArtifactName: 'drop-$(_RID)'
                 publishLocation: 'Container'
                 parallel: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -32,11 +32,17 @@ extends:
         enabled: true
       binskim:
         analyzeTargetGlob: $(Build.SourcesDirectory)/artifacts/bin/**.dll;$(Build.SourcesDirectory)/artifacts/bin/**.exe;
+    pool:
+      pool:
+      name: $(DncEngInternalBuildPool)
+      image: 1es-windows-2022
+      os: windows
     customBuildTags:
     - ES365AIMigrationTooling
     stages:
     - stage: build
       displayName: Build
+
       jobs:
       - template: /eng/common/templates-official/jobs/jobs.yml@self
         parameters:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -114,7 +114,7 @@ extends:
             - task: MicroBuildCodesignVerify@3
               inputs:
                 TargetFolders: '$(Build.ArtifactStagingDirectory)\artifacts'
-                ExcludeFolders: '.git MicroBuild'
+                ExcludeFolders: '.git MicroBuild .cab'
                 ExcludeSNVerify: true
             - task: 1ES.PublishBuildArtifacts@1
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -107,7 +107,7 @@ extends:
               displayName: Build and Publish
             - task: MicroBuildCodesignVerify@3
               inputs:
-                TargetFolders: 'artifacts/packages/$(_BuildConfig)/Shipping/'
+                TargetFolders: 'artifacts/packages/$(_BuildConfig)/Shipping/*.msi'
             - task: CopyFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -107,7 +107,7 @@ extends:
               displayName: Build and Publish
             - task: MicroBuildCodesignVerify@3
               inputs:
-                TargetFolders: 'artifacts/packages/$(_BuildConfig)/Shipping/*.msi'
+                TargetFolders: 'artifacts/packages/$(_BuildConfig)/Shipping'
             - task: CopyFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -114,8 +114,8 @@ extends:
             - task: MicroBuildCodesignVerify@3
               inputs:
                 TargetFolders: '$(Build.ArtifactStagingDirectory)\artifacts'
-                ExcludeFolders: '.git MicroBuild .cab'
                 ExcludeSNVerify: true
+                ApprovalListPathForCerts: eng\SignVerifyIgnore.txt
             - task: 1ES.PublishBuildArtifacts@1
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -106,9 +106,8 @@ extends:
                 /p:RID=$(_RID)
               displayName: Build and Publish
             - script: |
-                - script: |
-                  $msiFile = Get-ChildItem -Path "artifacts/packages/$(_BuildConfig)/Shipping" -Filter "*.msi" | Select-Object -First 1
-                  certutil -verify -urlfetch $msiFile.FullName
+                $msiFile = Get-ChildItem -Path "artifacts/packages/$(_BuildConfig)/Shipping" -Filter "*.msi" | Select-Object -First 1
+                certutil -verify -urlfetch $msiFile.FullName
               name: VerifySignature
               displayName: Verify Signature
             - task: CopyFiles@2

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -99,8 +99,6 @@ extends:
               - name: _OfficialBuildArgs
                 value: ''
             steps:
-            - checkout: self
-              clean: true
             - script: eng\common\cibuild.cmd
                 -configuration $(_BuildConfig)
                 -prepareMachine
@@ -110,7 +108,8 @@ extends:
             - script: |
                 # Verify the signature of the MSI
                 signtool verify /pa /v artifacts/packages/$(_BuildConfig)/Shipping/dotnet-core-uninstall-$(_RID).msi
-              name: Verify Signature
+              name: VerifySignature
+              displayName: Verify Signature
             - task: CopyFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:
@@ -137,8 +136,6 @@ extends:
                 X64:
                   _RID: osx-x64
             steps:
-            - checkout: self
-              clean: true
             - script: eng/common/cibuild.sh
                 --sign
                 --configuration Release
@@ -147,7 +144,8 @@ extends:
               displayName: Build
             - script: |
                 codesign -dv --verbose=4 artifacts/layout/dotnet-core-uninstall/dotnet-core-uninstall
-              name: Verify Signature
+              name: VerifySignature
+              displayName: Verify Signature
             - task: ArchiveFiles@2
               condition: eq(variables['system.pullrequest.isfork'], false)
               inputs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -106,8 +106,7 @@ extends:
                 /p:RID=$(_RID)
               displayName: Build and Publish
             - script: |
-                # Verify the signature of the MSI
-                signtool verify /pa /v artifacts/packages/$(_BuildConfig)/Shipping/dotnet-core-uninstall-$(_RID).msi
+                certutil -verify -urlfetch artifacts/packages/$(_BuildConfig)/Shipping/dotnet-core-uninstall.msi
               name: VerifySignature
               displayName: Verify Signature
             - task: CopyFiles@2

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -136,15 +136,12 @@ extends:
               value: Release
             - name: _SignType
               value: real
-            parameters:
-              enableMicrobuild: true
-              enableMicrobuildForMacAndLinux: true
             steps:
             - script: eng/common/cibuild.sh
                 -sign
-                --configuration Release
+                --configuration $(_BuildConfig)
                 --prepareMachine
-                -p:RID=$(_RID) -p:DotNetSignType=real -p:TeamName=$(TeamName) -p:OfficialBuildId=$(Build.BuildNumber)
+                -p:RID=$(_RID) -p:DotNetSignType=$(_SignType) -p:TeamName=$(TeamName) -p:OfficialBuildId=$(Build.BuildNumber)
               displayName: Build
             - script: |
                 codesign -dv --verbose=4 artifacts/layout/dotnet-core-uninstall/dotnet-core-uninstall

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -138,6 +138,9 @@ extends:
             variables:
             - name: _BuildConfig
               value: Release
+            parameters:
+              enableMicrobuild: true
+              enableMicrobuildForMacAndLinux: true
             steps:
             - script: eng/common/cibuild.sh
                 -sign

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -32,10 +32,6 @@ extends:
         enabled: true
       binskim:
         analyzeTargetGlob: $(Build.SourcesDirectory)/artifacts/bin/**.dll;$(Build.SourcesDirectory)/artifacts/bin/**.exe;
-    pool:
-      name: $(DncEngInternalBuildPool)
-      image: 1es-windows-2022
-      os: windows
     customBuildTags:
     - ES365AIMigrationTooling
     stages:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -105,15 +105,15 @@ extends:
                 $(_BuildArgs)
                 /p:RID=$(_RID)
               displayName: Build and Publish
-            - task: MicroBuildCodesignVerify@3
-              inputs:
-                TargetFolders: 'artifacts/packages/$(_BuildConfig)/Shipping'
             - task: CopyFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:
                 sourceFolder: 'artifacts/packages/$(_BuildConfig)/Shipping/'
                 contents: '*.msi'
                 targetFolder: '$(Build.ArtifactStagingDirectory)'
+            - task: MicroBuildCodesignVerify@3
+              inputs:
+                TargetFolders: '$(Build.ArtifactStagingDirectory)'
             - task: 1ES.PublishBuildArtifacts@1
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -115,6 +115,7 @@ extends:
               inputs:
                 TargetFolders: '$(Build.ArtifactStagingDirectory)\artifacts'
                 ExcludeFolders: '.git MicroBuild'
+                ExcludeSNVerify: true
             - task: 1ES.PublishBuildArtifacts@1
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:
@@ -139,7 +140,7 @@ extends:
               value: Release
             steps:
             - script: eng/common/cibuild.sh
-                --sign
+                -sign
                 --configuration Release
                 --prepareMachine
                 -p:RID=$(_RID) -p:DotNetSignType=real -p:TeamName=$(TeamName) -p:OfficialBuildId=$(Build.BuildNumber)

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -134,6 +134,8 @@ extends:
             variables:
             - name: _BuildConfig
               value: Release
+            - name: _SignType
+              value: real
             parameters:
               enableMicrobuild: true
               enableMicrobuildForMacAndLinux: true

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -134,6 +134,9 @@ extends:
                   _RID: osx-arm64
                 X64:
                   _RID: osx-x64
+            variables:
+            - name: _BuildConfig
+              value: Release
             steps:
             - script: eng/common/cibuild.sh
                 --sign

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -105,11 +105,9 @@ extends:
                 $(_BuildArgs)
                 /p:RID=$(_RID)
               displayName: Build and Publish
-            - script: |
-                $msiFile = Get-ChildItem -Path "artifacts/packages/$(_BuildConfig)/Shipping" -Filter "*.msi" | Select-Object -First 1
-                certutil -verify -urlfetch $msiFile.FullName
-              name: VerifySignature
-              displayName: Verify Signature
+            - task: MicroBuildCodesignVerify@3
+              inputs:
+                TargetFolders: 'artifacts/packages/$(_BuildConfig)/Shipping/'
             - task: CopyFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -107,6 +107,10 @@ extends:
                 $(_BuildArgs)
                 /p:RID=$(_RID)
               displayName: Build and Publish
+            - script: |
+                # Verify the signature of the MSI
+                signtool verify /pa /v artifacts/packages/$(_BuildConfig)/Shipping/dotnet-core-uninstall-$(_RID).msi
+              name: Verify Signature
             - task: CopyFiles@2
               condition: and(eq(variables['system.pullrequest.isfork'], false), eq(variables['_BuildConfig'], 'Release'))
               inputs:
@@ -141,6 +145,9 @@ extends:
                 --prepareMachine
                 -p:RID=$(_RID) -p:DotNetSignType=real -p:TeamName=$(TeamName) -p:OfficialBuildId=$(Build.BuildNumber)
               displayName: Build
+            - script: |
+                codesign -dv --verbose=4 artifacts/layout/dotnet-core-uninstall/dotnet-core-uninstall
+              name: Verify Signature
             - task: ArchiveFiles@2
               condition: eq(variables['system.pullrequest.isfork'], false)
               inputs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -106,7 +106,9 @@ extends:
                 /p:RID=$(_RID)
               displayName: Build and Publish
             - script: |
-                certutil -verify -urlfetch artifacts/packages/$(_BuildConfig)/Shipping/dotnet-core-uninstall.msi
+                - script: |
+                  $msiFile = Get-ChildItem -Path "artifacts/packages/$(_BuildConfig)/Shipping" -Filter "*.msi" | Select-Object -First 1
+                  certutil -verify -urlfetch $msiFile.FullName
               name: VerifySignature
               displayName: Verify Signature
             - task: CopyFiles@2

--- a/eng/SignVerifyIgnore.txt
+++ b/eng/SignVerifyIgnore.txt
@@ -1,0 +1,2 @@
+**\*.xml,ignore unsigned .xml
+**\cab*.cab.cab,ignore unsigned .cab

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -6,8 +6,9 @@
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">
     <FileExtensionSignInfo Include=".wixpdb;.cab" CertificateName="MicrosoftDotNet500" />
+    <FileSignInfo Include="cab1.cab" CertificateName="MicrosoftDotNet500" />
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**\*.wixpack.zip;
-      $(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi;" />
+      $(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -11,19 +11,8 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
-    <!--
-      This is intended to hold information about the certificates used for signing.
-    -->
-    <CertificatesSignInfo Include="3PartyDual" DualSigningAllowed="true" />
-    <CertificatesSignInfo Include="3PartySHA2" DualSigningAllowed="true" />
-    <!-- This signing information indicates certificates that represent a sign and notarize operation. -->
-    <CertificatesSignInfo Include="MacDeveloperHardenWithNotarization" MacCertificate="MacDeveloperHarden" MacNotarizationAppName="dotnet" />
-    <CertificatesSignInfo Include="MacDeveloperWithNotarization" MacCertificate="MacDeveloper" MacNotarizationAppName="dotnet" />
-    <CertificatesSignInfo Include="MacDeveloperVNextWithNotarization" MacCertificate="MacDeveloperVNext" MacNotarizationAppName="dotnet" />
-    <CertificatesSignInfo Include="MacDeveloperVNextHardenWithNotarization" MacCertificate="MacDeveloperVNextHarden" MacNotarizationAppName="dotnet" />
-
-    <FileSignInfo Include="dotnet-core-uninstall" CertificateName="MacDeveloperHardenWithNotarization" />
-    <FileSignInfo Include="dotnet-core-uninstall.pdb" CertificateName="MacDeveloperHardenWithNotarization" />
+    <FileSignInfo Include="dotnet-core-uninstall" CertificateName="MacDeveloperHarden" />
+    <FileSignInfo Include="dotnet-core-uninstall.pdb" CertificateName="MacDeveloperHarden" />
     <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*" />
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">
-    <FileExtensionSignInfo Include=".wixpdb" CertificateName="MicrosoftDotNet500" />
+    <FileExtensionSignInfo Include=".wixpdb;.cab" CertificateName="MicrosoftDotNet500" />
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**\*.wixpack.zip;
       $(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi;" />
   </ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -5,8 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">
-    <FileExtensionSignInfo Include=".wixpdb;.cab" CertificateName="MicrosoftDotNet500" />
-    <FileSignInfo Include="cab1.cab" CertificateName="MicrosoftDotNet500" />
+    <FileExtensionSignInfo Include=".wixpdb" CertificateName="MicrosoftDotNet500" />
     <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**\*.wixpack.zip;
       $(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi" />
   </ItemGroup>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -11,8 +11,19 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'">
-    <FileSignInfo Include="dotnet-core-uninstall" CertificateName="MacDeveloperHarden" />
-    <FileSignInfo Include="dotnet-core-uninstall.pdb" CertificateName="MacDeveloperHarden" />
+    <!--
+      This is intended to hold information about the certificates used for signing.
+    -->
+    <CertificatesSignInfo Include="3PartyDual" DualSigningAllowed="true" />
+    <CertificatesSignInfo Include="3PartySHA2" DualSigningAllowed="true" />
+    <!-- This signing information indicates certificates that represent a sign and notarize operation. -->
+    <CertificatesSignInfo Include="MacDeveloperHardenWithNotarization" MacCertificate="MacDeveloperHarden" MacNotarizationAppName="dotnet" />
+    <CertificatesSignInfo Include="MacDeveloperWithNotarization" MacCertificate="MacDeveloper" MacNotarizationAppName="dotnet" />
+    <CertificatesSignInfo Include="MacDeveloperVNextWithNotarization" MacCertificate="MacDeveloperVNext" MacNotarizationAppName="dotnet" />
+    <CertificatesSignInfo Include="MacDeveloperVNextHardenWithNotarization" MacCertificate="MacDeveloperVNextHarden" MacNotarizationAppName="dotnet" />
+
+    <FileSignInfo Include="dotnet-core-uninstall" CertificateName="MacDeveloperHardenWithNotarization" />
+    <FileSignInfo Include="dotnet-core-uninstall.pdb" CertificateName="MacDeveloperHardenWithNotarization" />
     <ItemsToSign Include="$(ArtifactsDir)layout/dotnet-core-uninstall/*" />
   </ItemGroup>
 </Project>

--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
+    <DotNetCertificateName>MicrosoftDotNet500</DotNetCertificateName>
     <UseDotNetCertificate>true</UseDotNetCertificate>
   </PropertyGroup>
 

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\dotnet-core-uninstall\dotnet-core-uninstall.csproj" />
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25124.4" Condition="'$(RID)' == 'win-x86'"/>
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25124.4" />
   </ItemGroup>
 
   <Import Condition="'$(RID)' == 'win-x86'" Project="targets\Versions.targets" />

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -21,6 +21,6 @@
   <Target Condition="'$(RID)' == 'win-x86'" Name="GenerateMSIs" AfterTargets="Build" DependsOnTargets="GenerateLayout;GenerateDotnetCoreUninstallMsi" />
 
   <!-- Entitlements are needed but not automatically added for macOS. See https://github.com/dotnet/runtime/issues/113707 -->
-  <Import Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'" Project="targets\MacEntitlements\AddMacEntitlements.targets" />
+  <!-- <Import Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'" Project="targets\MacEntitlements\AddMacEntitlements.targets" /> -->
   
 </Project>

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\dotnet-core-uninstall\dotnet-core-uninstall.csproj" />
-    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25124.4" />
+    <PackageReference Include="Microsoft.DotNet.Build.Tasks.Installers" Version="10.0.0-beta.25124.4" Condition="'$(RID)' == 'win-x86'"/>
   </ItemGroup>
 
   <Import Condition="'$(RID)' == 'win-x86'" Project="targets\Versions.targets" />

--- a/src/redist/redist.csproj
+++ b/src/redist/redist.csproj
@@ -21,6 +21,6 @@
   <Target Condition="'$(RID)' == 'win-x86'" Name="GenerateMSIs" AfterTargets="Build" DependsOnTargets="GenerateLayout;GenerateDotnetCoreUninstallMsi" />
 
   <!-- Entitlements are needed but not automatically added for macOS. See https://github.com/dotnet/runtime/issues/113707 -->
-  <!-- <Import Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'" Project="targets\MacEntitlements\AddMacEntitlements.targets" /> -->
+  <Import Condition="'$(RID)' == 'osx-x64' OR '$(RID)' == 'osx-arm64'" Project="targets\MacEntitlements\AddMacEntitlements.targets" />
   
 </Project>

--- a/src/redist/targets/MacEntitlements/AddMacEntitlements.targets
+++ b/src/redist/targets/MacEntitlements/AddMacEntitlements.targets
@@ -1,7 +1,12 @@
 <Project>
     <!-- Entitlements are needed but not automatically added for macOS. See https://github.com/dotnet/runtime/issues/113707 -->
     <!-- This generates an ad-hoc signature that will later be resigned, but keeps the entitlements. -->
-    <Target Name="AddMacEntitlements" AfterTargets="GenerateLayout">
+    <ItemGroup>
+        <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="$(MicrosoftVisualStudioEngMicroBuildCoreVersion)" />
+    </ItemGroup>
+    <Target Name="AddMacEntitlements" 
+        BeforeTargets="SignFiles" 
+        AfterTargets="AfterBuild">
         <Exec Command="codesign -s - -f --entitlements $(MSBuildThisFileDirectory)entitlements.plist $(ArtifactsDir)layout/dotnet-core-uninstall/dotnet-core-uninstall" />
     </Target>
 </Project>

--- a/src/redist/targets/MacEntitlements/AddMacEntitlements.targets
+++ b/src/redist/targets/MacEntitlements/AddMacEntitlements.targets
@@ -6,7 +6,7 @@
     </ItemGroup>
     <Target Name="AddMacEntitlements" 
         BeforeTargets="SignFiles" 
-        AfterTargets="AfterBuild">
+        AfterTargets="GenerateLayout">
         <Exec Command="codesign -s - -f --entitlements $(MSBuildThisFileDirectory)entitlements.plist $(ArtifactsDir)layout/dotnet-core-uninstall/dotnet-core-uninstall" />
     </Target>
 </Project>


### PR DESCRIPTION
Signatures are not working properly after latest Arcade update.

This fixes the issues and adds an extra step for signature verification so that these are easier to debug in the future.