### PR TITLE
Mac: Add rid to tar.gz artifacts

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -159,7 +159,7 @@ extends:
                 includeRootFolder: false
                 archiveType: 'tar'
                 tarCompression: 'gz'
-                archiveFile: '$(Build.ArtifactStagingDirectory)/artifacts/dotnet-core-uninstall.tar.gz'
+                archiveFile: '$(Build.ArtifactStagingDirectory)/artifacts/dotnet-core-uninstall-$(_RID).tar.gz'
                 replaceExistingArchive: true
             - task: 1ES.PublishBuildArtifacts@1
               condition: eq(variables['system.pullrequest.isfork'], false)


### PR DESCRIPTION
Currently, the pipelines generates .tar.gz for both amr64 and x64 macs with the same name. This makes it so that they are identifiable by RID