### PR TITLE
Windows: Remove version from .msi

### DIFF
--- a/src/redist/targets/GenerateMSIs.targets
+++ b/src/redist/targets/GenerateMSIs.targets
@@ -24,7 +24,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-      <ArtifactNameWithVersionDotnetCoreUninstall>dotnet-core-uninstall-$(Version)</ArtifactNameWithVersionDotnetCoreUninstall>
+      <ArtifactNameWithVersionDotnetCoreUninstall>dotnet-core-uninstall</ArtifactNameWithVersionDotnetCoreUninstall>
       <DotnetCoreUninstallMSIInstallerFile>$(ArtifactsShippingPackagesDir)$(ArtifactNameWithVersionDotnetCoreUninstall)$(InstallerExtension)</DotnetCoreUninstallMSIInstallerFile>
     </PropertyGroup>
   </Target>


### PR DESCRIPTION
Related to #383 and #314
Exploring idea of removing version number from .msi filename

Note that the filenames can be modified during the GitHub release process, so this more of a convenience change, and up for discussion :) 