### PR TITLE
Update wixpack path

### DIFF
--- a/eng/Signing.props
+++ b/eng/Signing.props
@@ -6,7 +6,7 @@
 
   <ItemGroup Condition="'$(RID)' == 'win-x86'">
     <FileExtensionSignInfo Include=".wixpdb" CertificateName="MicrosoftDotNet500" />
-    <ItemsToSign Include="$(ArtifactsShippingPackagesDir)**\*.wixpack.zip;
+    <ItemsToSign Include="$(ArtifactsNonShippingPackagesDir)**\*.wixpack.zip;
       $(ArtifactsDir)packages\**\dotnet-core-uninstall*.msi" />
   </ItemGroup>
 


### PR DESCRIPTION
Wixpack path changed with Wix 5 work. This PR updates the signing properties, so we get repack/resign of the MSI.