### PR TITLE
Fix GenerateMsiVersion task parameter names to match targets file

### DIFF
--- a/src/core-sdk-tasks/GenerateMsiVersion.cs
+++ b/src/core-sdk-tasks/GenerateMsiVersion.cs
@@ -9,16 +9,16 @@ namespace Microsoft.DotNet.Cli.Build
     public class GenerateMsiVersion : Task
     {
         [Required]
-        public int CommitCount { get; set; }
+        public int BuildNumber { get; set; }
 
         [Required]
-        public int VersionMajor { get; set; }
+        public int Major { get; set; }
 
         [Required]
-        public int VersionMinor { get; set; }
+        public int Minor { get; set; }
 
         [Required]
-        public int VersionPatch { get; set; }
+        public int Patch { get; set; }
 
         [Output]
         public string MsiVersion { get; set; }
@@ -27,10 +27,10 @@ namespace Microsoft.DotNet.Cli.Build
         {
             var buildVersion = new Version()
             {
-                Major = VersionMajor,
-                Minor = VersionMinor,
-                Patch = VersionPatch,
-                CommitCount = CommitCount
+                Major = Major,
+                Minor = Minor,
+                Patch = Patch,
+                CommitCount = BuildNumber
             };
 
             MsiVersion = buildVersion.GenerateMsiVersion();


### PR DESCRIPTION
## Summary

The `GenerateMSIs.targets` file passes `BuildNumber`, `Major`, `Minor`, and `Patch` parameters to the `GenerateMsiVersion` task, but the C# task class in `core-sdk-tasks` had different property names (`CommitCount`, `VersionMajor`, `VersionMinor`, `VersionPatch`).

## Root Cause

Previously, this mismatch was hidden because the arcade-provided `GenerateMsiVersion` task (from `Microsoft.DotNet.Build.Tasks.Installers`) was being selected by MSBuild at runtime. However, the latest arcade SDK update (PR #440) adds `Runtime="NET" Architecture="*"` qualifiers to its `UsingTask` declarations (workaround for msbuild#13739), which changes MSBuild task resolution priority and causes the local `core-sdk-tasks` version to be selected instead, exposing the parameter name mismatch.

## Fix

Renamed the C# properties in `GenerateMsiVersion.cs` to match what the targets file passes:

| Old name | New name |
|---|---|
| `CommitCount` | `BuildNumber` |
| `VersionMajor` | `Major` |
| `VersionMinor` | `Minor` |
| `VersionPatch` | `Patch` |

This unblocks PR #440 (arcade dependency update).