### PR TITLE
Remove direct Publish-Build-Assets imports

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -87,8 +87,6 @@ extends:
                 value: $(_OfficialBuildArgs)
             # Only enable publishing in official builds.
             - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-              # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-              - group: Publish-Build-Assets
               - name: _OfficialBuildArgs
                 value: /p:DotNetSignType=$(_SignType)
                       /p:SignCoreDotnetCoreUninstall=true

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -44,8 +44,6 @@ stages:
           value: win-x86
         # Only enable publishing in official builds.
         - ${{ if and(ne(variables['System.TeamProject'], 'public'), notin(variables['Build.Reason'], 'PullRequest')) }}:
-          # Publish-Build-Assets provides: MaestroAccessToken, BotAccount-dotnet-maestro-bot-PAT
-          - group: Publish-Build-Assets
           - name: _OfficialBuildArgs
             value: /p:DotNetSignType=$(_SignType)
                    /p:SignCoreDotnetCoreUninstall=true


### PR DESCRIPTION
## Summary
- remove direct `Publish-Build-Assets` imports from the CI and PR pipeline YAML
- leave shared `eng/common` cleanup to the Arcade dependency flow

The expanded pipeline does not reference any variable currently supplied by VG20, so no replacement variable group is required.

Tracking: https://dev.azure.com/dnceng/internal/_workitems/edit/12131